### PR TITLE
+ and - larger on xyz wheel can also center click on speed wheel to return to xyzw…

### DIFF
--- a/dashboard/static/css/style.css
+++ b/dashboard/static/css/style.css
@@ -443,7 +443,6 @@ ul.off-canvas-list li a, ul.off-canvas-list li.no-link {
 }
 
 #position ul li:first-child label {
-	color: #dd8728;
 	font-size: 36px;
 	font-size: 1.5rem;
 	font-family: 'source_sans_proextralight';
@@ -814,6 +813,18 @@ ul.off-canvas-list li a, ul.off-canvas-list li.no-link {
 	left: 20px;
 	left: 0.625rem
 }
+
+#speedwheelLabel {
+	position: relative;
+	bottom: -10px;
+	font-size: 1.1em;
+	font-weight: 300;
+	font-family: 'source_sans_proextralight';
+	display: none;
+}
+
+
+
 
 /*Test Trackpad*/
 #keypad.trackpad #trackpad-zone {

--- a/dashboard/static/css/style.css
+++ b/dashboard/static/css/style.css
@@ -28,7 +28,7 @@ body,html{
 }
 
 .exit-off-canvas {
-	height: 100%;
+	position: fixed !important;
 }
 
 .disabled {

--- a/dashboard/static/index.html
+++ b/dashboard/static/index.html
@@ -134,6 +134,7 @@
               </ul>
             </div>
             <div id="handwheel" class="widget fabmo-manual-control" style="text-align: center;">
+              <span id="speedwheelLabel">Speed Adjustment</span>
               <canvas width="220" height="220" id="wheel"></canvas>
             </div>
             <ul class="off-canvas-list fabmo-status fabmo-file-control">

--- a/dashboard/static/js/libs/handwheel.js
+++ b/dashboard/static/js/libs/handwheel.js
@@ -67,6 +67,17 @@ var WheelControl = function(element, options) {
     	position : this.wheelSpeed,
     	centerText : this.wheelSpeed.toFixed(this.speedDigits)
     });
+    
+     // Arrow for negative nudge
+    var minusnudge = new Nudger({
+    	radius : this.radius,
+    	center : this.center,
+    	endAngle : 3.0*Math.PI/2.0,
+    	startAngle : 5.0*Math.PI/4.0,
+    	arrow : 'start',
+    	labelStyle : '25px Arial',
+    	labelText : '-'
+    });
 
     // Arrow for positive nudge
     var plusnudge = new Nudger({
@@ -75,20 +86,11 @@ var WheelControl = function(element, options) {
     	startAngle : 3.0*Math.PI/2.0,
     	endAngle : 7.0*Math.PI/4.0,
     	arrow : 'end',
-    	labelStyle : '20px Arial',
+    	labelStyle : '25px Arial',
     	labelText : '+'
     });
 
-    // Arrow for negative nudge
-    var minusnudge = new Nudger({
-    	radius : this.radius,
-    	center : this.center,
-    	endAngle : 3.0*Math.PI/2.0,
-    	startAngle : 5.0*Math.PI/4.0,
-    	arrow : 'start',
-    	labelStyle : '20px Arial',
-    	labelText : '-'
-    });
+   
 
     // List of controls with access to the canvas context
     this.controls.push(speedwheel);
@@ -111,6 +113,15 @@ var WheelControl = function(element, options) {
     	plusnudge.hide();
     	minusnudge.hide();
     	speedwheel.show();
+    	this.draw();
+    }.bind(this));
+    
+   // Center click on the speedwheel switches us back to xyzwheel
+    speedwheel.on('center', function switchToxyzwheel() {
+    	xyzwheel.show();
+    	plusnudge.show();
+    	minusnudge.show();
+    	speedwheel.hide();
     	this.draw();
     }.bind(this));
 

--- a/dashboard/static/js/libs/handwheel.js
+++ b/dashboard/static/js/libs/handwheel.js
@@ -34,7 +34,7 @@ var WheelControl = function(element, options) {
     	center : this.center,
     	centerText : this.wheelSpeed.toFixed(this.speedDigits),
     	centerTextColor : '#aaaaaa',
-    	centerTextStyle : 'Arial 50px',
+    	centerTextStyle : 'Arial 25px',
     	thumbRadius : this.thumbRadius,
     	thumbActiveRadius : this.thumbActiveRadius,
     	angleOffset : Math.PI/3.0,

--- a/dashboard/static/js/libs/handwheel.js
+++ b/dashboard/static/js/libs/handwheel.js
@@ -34,7 +34,7 @@ var WheelControl = function(element, options) {
     	center : this.center,
     	centerText : this.wheelSpeed.toFixed(this.speedDigits),
     	centerTextColor : '#aaaaaa',
-    	centerTextStyle : 'Arial 20px',
+    	centerTextStyle : 'Arial 50px',
     	thumbRadius : this.thumbRadius,
     	thumbActiveRadius : this.thumbActiveRadius,
     	angleOffset : Math.PI/3.0,
@@ -113,6 +113,9 @@ var WheelControl = function(element, options) {
     	plusnudge.hide();
     	minusnudge.hide();
     	speedwheel.show();
+        $('#speedwheelLabel').show();
+        $('#wheel').css('position', 'relative');
+        $('#wheel').css('top', '-20px');
     	this.draw();
     }.bind(this));
     
@@ -122,6 +125,9 @@ var WheelControl = function(element, options) {
     	plusnudge.show();
     	minusnudge.show();
     	speedwheel.hide();
+        $('#speedwheelLabel').hide();
+        $('#wheel').css('position', 'static');
+        $('#wheel').css('top', '0px');
     	this.draw();
     }.bind(this));
 
@@ -145,6 +151,9 @@ var WheelControl = function(element, options) {
 	    	plusnudge.show();
 	    	minusnudge.show();
 	    	xyzwheel.show();
+            $('#speedwheelLabel').hide();
+            $('#wheel').css('position', 'static');
+            $('#wheel').css('top', '0px');
 	    	this.draw();
     	}.bind(this), 500);
     }.bind(this))


### PR DESCRIPTION
There is an issue where the X Y and Z inherit font size from the minus nudger that I am trying to understand but this seems like a happy compromise on size.  There also didn't seem to be an easy way to return the the xyz wheel after adjusting the speed. So I added ability to center click to return as well.