### PR TITLE
49248 footer resume fix

### DIFF
--- a/machine.js
+++ b/machine.js
@@ -943,6 +943,7 @@ Machine.prototype.quit = function(callback) {
 // Resume from the paused state.
 Machine.prototype.resume = function(callback, input=false) {
 	if (this.current_runtime && this.current_runtime.inFeedHold){
+		log.info("Machine detects in feedhold");
 		this._resume();
 	} else {
 		this.arm({
@@ -1063,6 +1064,7 @@ Machine.prototype._resume = function(input) {
 		break;
 	}
 	if(this.current_runtime) {
+		log.info("trigger current runtime resume")
 		this.current_runtime.resume(input)
 	}
 };

--- a/machine.js
+++ b/machine.js
@@ -1056,10 +1056,8 @@ Machine.prototype._executeRuntimeCode = function(runtimeName, code, callback) {
 
 // e
 Machine.prototype._resume = function(input) {
-	log.debug("machine _resume reached");
 	switch(this.status.state) {
 		case 'interlock':
-			log.debug("interlock case");
 			if(this.interlock_action) {
 				this.arm(this.interlock_action);
 				this.interlock_action = null;
@@ -1068,7 +1066,6 @@ Machine.prototype._resume = function(input) {
 		break;
 	}
 	if(this.current_runtime) {
-		log.debug("trigger current runtime resume")
 		this.current_runtime.resume(input)
 	}
 };

--- a/machine.js
+++ b/machine.js
@@ -881,10 +881,6 @@ Machine.prototype.setState = function(source, newstate, stateinfo) {
 	this.emit('status',this.status);
 	if (this.status.info && this.status.info['timer']){
 		setTimeout(function() {
-			// this.arm({
-			// 	'type' : 'resume',
-			// 	'input' : input
-			// }, config.machine.get('auth_timeout'));
 	        this.resume(function(err, msg){
 				if(err){
 					log.error(err);
@@ -946,11 +942,15 @@ Machine.prototype.quit = function(callback) {
 
 // Resume from the paused state.
 Machine.prototype.resume = function(callback, input=false) {
-	this.arm({
-		'type' : 'resume',
-		'input' : input
-	}, config.machine.get('auth_timeout'));
-	callback(null, 'resumed');
+	if (this.current_runtime && this.current_runtime.inFeedHold){
+		this._resume();
+	} else {
+		this.arm({
+			'type' : 'resume',
+			'input' : input
+		}, config.machine.get('auth_timeout'));
+		callback(null, 'resumed');
+	}
 }
 
 // Run a file from disk

--- a/machine.js
+++ b/machine.js
@@ -942,10 +942,12 @@ Machine.prototype.quit = function(callback) {
 
 // Resume from the paused state.
 Machine.prototype.resume = function(callback, input=false) {
+	log.debug("Machine Resume Reached")
 	if (this.current_runtime && this.current_runtime.inFeedHold){
-		log.info("Machine detects in feedhold");
+		log.debug("Machine detects in feedhold");
 		this._resume();
 	} else {
+		log.debug("feedhold not detected.")
 		this.arm({
 			'type' : 'resume',
 			'input' : input
@@ -1054,8 +1056,10 @@ Machine.prototype._executeRuntimeCode = function(runtimeName, code, callback) {
 
 // e
 Machine.prototype._resume = function(input) {
+	log.debug("machine _resume reached");
 	switch(this.status.state) {
 		case 'interlock':
+			log.debug("interlock case");
 			if(this.interlock_action) {
 				this.arm(this.interlock_action);
 				this.interlock_action = null;
@@ -1064,7 +1068,7 @@ Machine.prototype._resume = function(input) {
 		break;
 	}
 	if(this.current_runtime) {
-		log.info("trigger current runtime resume")
+		log.debug("trigger current runtime resume")
 		this.current_runtime.resume(input)
 	}
 };

--- a/routes/websocket.js
+++ b/routes/websocket.js
@@ -177,7 +177,7 @@ var onPrivateConnect = function(socket) {
 					break;
 
 				case 'resume':
-					if (data.args.var && data.args.val) {
+					if (data.args && data.args.var && data.args.val) {
 						machine.resume(callback, {'var':data.args.var, 'val':data.args.val});
 					}
 					log.debug("triggering machine resume");
@@ -186,9 +186,11 @@ var onPrivateConnect = function(socket) {
 
 				default:
 					// Meh?
+					log.debug("command switch hit default");
 					break;
 			}
 		} catch(e) {
+			log.error(e);
 			// pass
 		}
 	});

--- a/routes/websocket.js
+++ b/routes/websocket.js
@@ -180,7 +180,6 @@ var onPrivateConnect = function(socket) {
 					if (data.args && data.args.var && data.args.val) {
 						machine.resume(callback, {'var':data.args.var, 'val':data.args.val});
 					}
-					log.debug("triggering machine resume");
 					machine.resume(callback);
 					break;
 

--- a/routes/websocket.js
+++ b/routes/websocket.js
@@ -180,6 +180,7 @@ var onPrivateConnect = function(socket) {
 					if (data.args.var && data.args.val) {
 						machine.resume(callback, {'var':data.args.var, 'val':data.args.val});
 					}
+					log.debug("triggering machine resume");
 					machine.resume(callback);
 					break;
 

--- a/runtime/gcode/index.js
+++ b/runtime/gcode/index.js
@@ -40,6 +40,7 @@ GCodeRuntime.prototype.disconnect = function() {
 
 GCodeRuntime.prototype.pause = function() {
 	this.driver.feedHold();
+    this.inFeedHold = true;
 }
 
 GCodeRuntime.prototype.quit = function() {
@@ -48,6 +49,7 @@ GCodeRuntime.prototype.quit = function() {
 
 GCodeRuntime.prototype.resume = function() {
 	this.driver.resume();
+    this.inFeedHold = false;
 }
 
 GCodeRuntime.prototype._changeState = function(newstate) {

--- a/runtime/gcode/index.js
+++ b/runtime/gcode/index.js
@@ -9,6 +9,7 @@ function GCodeRuntime() {
 	this.driver = null;
 	this.ok_to_disconnect = true;
 	this.completeCallback = null;
+    this.inFeedHold = false;
 }
 
 GCodeRuntime.prototype.toString = function() {

--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -2003,8 +2003,11 @@ SBPRuntime.prototype.quit = function() {
 // Resume a program from the paused state
 //   TODO - make some indication that this action was successfil (resume is not always allowed, and sometimes it fails)
 SBPRuntime.prototype.resume = function(input=false) {
+        log.info("opensbp resume");
         if(this.resumeAllowed) {
+            log.info("resume allowed");
             if(this.paused) {
+                log.info("paused");
                 if (input) {
                     var callback = (function(err, data) {
                         if (err) {
@@ -2020,8 +2023,10 @@ SBPRuntime.prototype.resume = function(input=false) {
                     this._executeNext();
                 }
             } else {
+                log.info("Not paused trigger driver resume");
                 this.driver.resume();
                 this.inFeedHold = false;
+                log.info("driver resume triggered");
             }
         }
 }

--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -2003,11 +2003,8 @@ SBPRuntime.prototype.quit = function() {
 // Resume a program from the paused state
 //   TODO - make some indication that this action was successfil (resume is not always allowed, and sometimes it fails)
 SBPRuntime.prototype.resume = function(input=false) {
-        log.debug("opensbp resume");
         if(this.resumeAllowed) {
-            log.debug("resume allowed");
             if(this.paused) {
-                log.debug("paused");
                 if (input) {
                     var callback = (function(err, data) {
                         if (err) {
@@ -2023,10 +2020,8 @@ SBPRuntime.prototype.resume = function(input=false) {
                     this._executeNext();
                 }
             } else {
-                log.debug("Not paused trigger driver resume");
                 this.driver.resume();
                 this.inFeedHold = false;
-                log.debug("driver resume triggered");
             }
         }
 }

--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -2021,6 +2021,7 @@ SBPRuntime.prototype.resume = function(input=false) {
                 }
             } else {
                 this.driver.resume();
+                this.inFeedHold = false;
             }
         }
 }

--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -91,6 +91,7 @@ function SBPRuntime() {
     this.driver = null;
 
     this.inManualMode = false;
+    this.inFeedHold = false;
 
 }
 util.inherits(SBPRuntime, events.EventEmitter);
@@ -1980,6 +1981,7 @@ SBPRuntime.prototype.pause = function() {
         this.pendingFeedhold = true;
     } else {
         this.machine.driver.feedHold();
+        this.inFeedHold = true;
     }
 }
 

--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -2003,11 +2003,11 @@ SBPRuntime.prototype.quit = function() {
 // Resume a program from the paused state
 //   TODO - make some indication that this action was successfil (resume is not always allowed, and sometimes it fails)
 SBPRuntime.prototype.resume = function(input=false) {
-        log.info("opensbp resume");
+        log.debug("opensbp resume");
         if(this.resumeAllowed) {
-            log.info("resume allowed");
+            log.debug("resume allowed");
             if(this.paused) {
-                log.info("paused");
+                log.debug("paused");
                 if (input) {
                     var callback = (function(err, data) {
                         if (err) {
@@ -2023,10 +2023,10 @@ SBPRuntime.prototype.resume = function(input=false) {
                     this._executeNext();
                 }
             } else {
-                log.info("Not paused trigger driver resume");
+                log.debug("Not paused trigger driver resume");
                 this.driver.resume();
                 this.inFeedHold = false;
-                log.info("driver resume triggered");
+                log.debug("driver resume triggered");
             }
         }
 }


### PR DESCRIPTION
Got resume from feedhold working by clicking the resume button in the footer.  Still works to trigger resume on timed pauses when no pop up is present (under 10seconds).

needs testing and validation for both sbp and g2 runtimes.
