### PR TITLE
49508 remove timer on resume

### DIFF
--- a/machine.js
+++ b/machine.js
@@ -944,12 +944,9 @@ Machine.prototype.quit = function(callback) {
 
 // Resume from the paused state.
 Machine.prototype.resume = function(callback, input=false) {
-	log.debug("Machine Resume Reached")
 	if (this.current_runtime && this.current_runtime.inFeedHold){
-		log.debug("Machine detects in feedhold");
 		this._resume();
 	} else {
-		log.debug("feedhold not detected.")
 		if (this.pauseTimer) {
 			clearTimeout(this.pauseTimer);
 			this.pauseTimer = false;


### PR DESCRIPTION
Current master has the timer continue to count down after resume.  This can lead to an automated unpause during a non-timed pause.  This fixes that issue to ensure the timer is cleared on resume.