### PR TITLE
testing initialization with S-value; G2 fix for spin-up delay requires a default S-value

### DIFF
--- a/g2.js
+++ b/g2.js
@@ -197,9 +197,14 @@ G2.prototype._createCycleContext = function() {
 	////## added spaces after '\n's to make debug display easier to read
 	// TODO factor this out; ////## really???
 	// Inject a couple of G-Codes which are needed to start the machining cycle
+////##
+	st.write('G90\n ' + 'S1000\n ' + 'G61\n ')  ////## AND, make sure we have a default S-value
+////## S-value needed for G2 spinup-delay to work (ugh!not M3 switch)
+////## TODO create default variable for S-value for VFD spindle control, just a dummy here now
 	st.write('G90\n ' + 'G61\n ')  ////## to make sure we are not in exact stop mode left from fixed moves
 //	st.write('G90\n')
 	st.write('M100 ({out4:1})\n ') // hack to get the "permissive relay" behavior while in-cycle
+////## v3 version of G2 is not yet "in cycle here"; an increasing problem!
 	
 	// Handle data coming in on the stream
 	st.on('data', function(chunk) {


### PR DESCRIPTION
-this makes things work better for SBP files
-an S-value in code will over-ride
-*eventually needs integration with however spindle speed control is done in SBP in FabMo