### PR TITLE
Express system variable index with user variable

### DIFF
--- a/runtime/opensbp/sbp_parser.js
+++ b/runtime/opensbp/sbp_parser.js
@@ -1615,7 +1615,7 @@ module.exports = (function(){
           pos = pos1;
         }
         if (result0 !== null) {
-          result0 = (function(offset, v) {return v.join("")})(pos0, result0);
+          result0 = (function(offset, v) {return {"type":"user_variable", "expr":v.join("")}})(pos0, result0);
         }
         if (result0 === null) {
           pos = pos0;
@@ -1651,7 +1651,7 @@ module.exports = (function(){
           pos = pos1;
         }
         if (result0 !== null) {
-          result0 = (function(offset, v) {return v.join("")})(pos0, result0);
+          result0 = (function(offset, v) {return {"type":"persistent_variable", "expr":v.join("")}})(pos0, result0);
         }
         if (result0 === null) {
           pos = pos0;
@@ -1687,7 +1687,7 @@ module.exports = (function(){
           if (result1 !== null) {
             result2 = parse___();
             if (result2 !== null) {
-              result3 = parse_integer();
+              result3 = parse_e1();
               if (result3 !== null) {
                 result4 = parse___();
                 if (result4 !== null) {
@@ -1727,7 +1727,7 @@ module.exports = (function(){
           pos = pos1;
         }
         if (result0 !== null) {
-          result0 = (function(offset, v) {return v.join("")})(pos0, result0);
+          result0 = (function(offset, e) {return {"type":"system_variable", "expr":e}})(pos0, result0[3]);
         }
         if (result0 === null) {
           pos = pos0;
@@ -2516,6 +2516,7 @@ module.exports = (function(){
   result.SyntaxError = function(expected, found, offset, line, column) {
     function buildMessage(expected, found) {
       var expectedHumanized, foundHumanized;
+      
       switch (expected.length) {
         case 0:
           expectedHumanized = "end of input";

--- a/runtime/opensbp/sbp_parser.pegjs
+++ b/runtime/opensbp/sbp_parser.pegjs
@@ -98,13 +98,13 @@ variable
   = (user_variable / system_variable / persistent_variable)
 
 user_variable
-  = v:("&" identifier) {return v.join("")}
+  = v:("&" identifier) {return {"type":"user_variable", "expr":v.join("")}}
 
 persistent_variable
-  = v:("$" identifier ) {return v.join("")}
+  = v:("$" identifier ) {return {"type":"persistent_variable", "expr":v.join("")}}
 
 system_variable
-  = v:("%" "(" __ integer __ ")") {return v.join("")}
+  = "%" "(" __ e:expression __ ")" {return {"type":"system_variable", "expr":e}}
 
 assignment
   = v:variable __ "=" __ e:expression {return {"type": "assign", "var":v, "expr":e}}


### PR DESCRIPTION
Add feature parity in the sbp language parser equivalent to the SBP3
ability to express the index of a system variable by using a user
variable. It makes possible constructions such as
&SYS_VAR_XPOS = 1
&CURRENT_XPOS = %(&SYS_VAR_XPOS)