### PR TITLE
49828 prepend refactor

### DIFF
--- a/g2.js
+++ b/g2.js
@@ -980,14 +980,14 @@ G2.prototype.command = function(obj) {
 
 // Works like runString above, but takes a list of lines instead of a string
 // TODO:  Refactor could remove this.  See G2.prototype.setMachinePosition TODO.
-G2.prototype.runList = function(l) {
-	var stringStream = new stream.Readable();
-	for(var i=0; i<l.length; i++) {
-		stringStream.push(l[i] + "\n");
-	}
-	stringStream.push(null);
-	return this.runStream(stringStream);
-}
+// G2.prototype.runList = function(l) {
+// 	var stringStream = new stream.Readable();
+// 	for(var i=0; i<l.length; i++) {
+// 		stringStream.push(l[i] + "\n");
+// 	}
+// 	stringStream.push(null);
+// 	return this.runStream(stringStream);
+// }
 
 // Return a promise that resolves when one of the provided states is encountered
 // states - a list of states which will cause the promise to resolve
@@ -1121,21 +1121,38 @@ G2.prototype.sendMore = function() {
 };
 
 // Set the position of the motion system using the G28.3 code
-// position - An object mapping axes to position values. Axes that are not included will not be updated. 
+// position - An object mapping axes to position values. Axes that are not included will not be updated.
 G2.prototype.setMachinePosition = function(position, callback) {
 ////## until uvw enabled	var axes = ['x','y','z','a','b','c','u','v','w']
 	var axes = ['x','y','z','a','b','c']
-	var gcodes = ['G21']
+	var gcodes = new stream.Readable();
+	gcodes.push('G21\n');
 	axes.forEach(function(axis) {
 		if(position[axis] != undefined) {
-			gcodes.push('G28.3 ' + axis + position[axis].toFixed(5));
+			gcodes.push('G28.3 ' + axis + position[axis].toFixed(5) + "\n");
 		}
 	});
 
-	gcodes.push(this.status.unit === 'in' ? 'G20' : 'G21');
-	// TODO:  Refactor to use runstream directly
-	this.runList(gcodes).then(function() {callback && callback()})
+	gcodes.push(this.status.unit === 'in' ? 'G20\n' : 'G21\n');
+	gcodes.push(null);
+	this.runStream(gcodes).then(function() {callback && callback()})
 }
+
+// OLD VERSION Requires runList()
+// G2.prototype.setMachinePosition = function(position, callback) {
+// ////## until uvw enabled	var axes = ['x','y','z','a','b','c','u','v','w']
+// 	var axes = ['x','y','z','a','b','c']
+// 	var gcodes = ['G21']
+// 	axes.forEach(function(axis) {
+// 		if(position[axis] != undefined) {
+// 			gcodes.push('G28.3 ' + axis + position[axis].toFixed(5));
+// 		}
+// 	});
+
+// 	gcodes.push(this.status.unit === 'in' ? 'G20' : 'G21');
+// 	// TODO:  Refactor to use runstream directly
+// 	this.runList(gcodes).then(function() {callback && callback()})
+// }
 
 // Function works like "once()" for a state change
 // callbacks is an associative array mapping states to callbacks

--- a/g2.js
+++ b/g2.js
@@ -1041,9 +1041,6 @@ G2.prototype.waitForState = function(states) {
 G2.prototype.runStream = function(s) {
 	log.info("from run stream to _createCycle")
 	this._createCycleContext();
-	s.on('data', (chunk) => {
-		log.debug(chunk)
-	});
 	s.pipe(this.context._stream);
 	return this.context;
 }

--- a/g2.js
+++ b/g2.js
@@ -42,6 +42,7 @@ var _promiseCounter = 1;
 var resumePending = false;
 var intendedClose = false;
 var THRESH = 1
+var PRIMED_THRESHOLD = 10
 
 var pat = /s*(G(28|38)\.\d|G2(0|1))/g
 
@@ -229,7 +230,7 @@ G2.prototype._createCycleContext = function() {
 				// Priming happens either when the number of lines to send reaches a certain threshold
 				// or the prime() function is called manually.
 				// TODO:  Factor out 10 (magic number) and put it at the top of the file so it can be changed easily.
-				if(this.gcode_queue.getLength() >= 10) {
+				if(this.gcode_queue.getLength() >= PRIMED_THRESHOLD) {
 					this._primed = true;
 				}
 				this.lineBuffer = [];
@@ -1109,14 +1110,14 @@ G2.prototype.sendMore = function() {
 		var count = this.gcode_queue.getLength();
 		if(this.lines_to_send >= THRESH) {
 				if(count >= THRESH || this._streamDone) {
-				// Send some lines, but no more than we are allowed per linemode protocol
-				var to_send = Math.min(this.lines_to_send, count);
-				var codes = this.gcode_queue.multiDequeue(to_send);
-				// Ensures that when we join below that we get a \n on the end
-				codes.push(""); 
-				if(codes.length > 1) {
-					this.lines_to_send -= to_send/*-offset*/;
-					this._write(codes.join('\n '), function() { });  ////## added space for reading
+					// Send some lines, but no more than we are allowed per linemode protocol
+					var to_send = Math.min(this.lines_to_send, count);
+					var codes = this.gcode_queue.multiDequeue(to_send);
+					// Ensures that when we join below that we get a \n on the end
+					codes.push(""); 
+					if(codes.length > 1) {
+						this.lines_to_send -= to_send/*-offset*/;
+						this._write(codes.join('\n '), function() { });  ////## added space for reading
 				}
 			}
 		}

--- a/g2.js
+++ b/g2.js
@@ -1038,9 +1038,12 @@ G2.prototype.waitForState = function(states) {
 // This allows us to run huge files from disk, or say, http, or from 
 // a stream processor that is streaming from one of those sources without
 // having to load the entire file into memory.
-G2.prototype.runStream = function(s) {
+G2.prototype.runStream = function(s, prime=false) {
 	log.info("from run stream to _createCycle")
 	this._createCycleContext();
+	if (prime) {
+		this.prime();
+	}
 	s.pipe(this.context._stream);
 	return this.context;
 }

--- a/g2.js
+++ b/g2.js
@@ -1040,6 +1040,9 @@ G2.prototype.waitForState = function(states) {
 G2.prototype.runStream = function(s) {
 	log.info("from run stream to _createCycle")
 	this._createCycleContext();
+	s.on('data', (chunk) => {
+		log.debug(chunk)
+	});
 	s.pipe(this.context._stream);
 	return this.context;
 }

--- a/g2.js
+++ b/g2.js
@@ -208,7 +208,8 @@ G2.prototype._createCycleContext = function() {
 //	st.write('G90\n')
 	// st.write('M100 ({out4:1})\n ') // hack to get the "permissive relay" behavior while in-cycle
 ////## v3 version of G2 is not yet "in cycle here"; an increasing problem!
-	var processChunk = function(chunk) {
+	// Handle data coming in on the stream
+	st.on('data', function(chunk) {
 		// Stream data comes in "chunks" which are often multiple lines
 		chunk = chunk.toString();
 		var newLines = false;
@@ -237,39 +238,7 @@ G2.prototype._createCycleContext = function() {
 		if(newLines) {
 			this.sendMore();
 		}
-	};
-	// Handle data coming in on the stream
-	// st.on('data', function(chunk) {
-	// 	// Stream data comes in "chunks" which are often multiple lines
-	// 	chunk = chunk.toString();
-	// 	var newLines = false;
-	// 	// Repartition incoming "chunked" data as lines
-	// 	for(var i=0; i<chunk.length; i++) {
-	// 		ch = chunk[i];
-	// 		this.lineBuffer.push(ch);
-	// 		if(ch === '\n') {
-	// 			newLines = true;
-	// 			var s = this.lineBuffer.join('').trim();
-
-	// 			// Enqueue individual lines in the g-code queue
-	// 			this.gcode_queue.enqueue(s);
-
-	// 			// The G2 sender doesn't actually start sending until it is "primed"
-	// 			// Priming happens either when the number of lines to send reaches a certain threshold
-	// 			// or the prime() function is called manually.
-	// 			// TODO:  Factor out 10 (magic number) and put it at the top of the file so it can be changed easily.
-	// 			if(this.gcode_queue.getLength() >= 10) {
-	// 				this._primed = true;
-	// 			}
-	// 			this.lineBuffer = [];
-	// 		}
-	// 	}
-	// 	// If new lines were enqueued as a part of the re-chunkification process, send them.
-	// 	if(newLines) {
-	// 		this.sendMore();
-	// 	}
-	// }.bind(this));
-	st.on('data', function(chunk) {processChunk(chunk).bind(this)}.bind(this));
+	}.bind(this));
 
 	// Set absolute, spindle speed default, units, and turn on output 4
 	st.write('G90\n ' + 'S1000\n ' + 'G61\n ' + 'M100 ({out4:1})\n ');
@@ -289,10 +258,10 @@ G2.prototype._createCycleContext = function() {
 	}.bind(this));
 
 	// Handle a stream being piped into this context (currently do nothing)
-	// st.on('pipe', function() {
-	// 	log.debug("Stream PIPE event");
-	// })
-	st.on('pipe', function(chunk) {processChunk(chunk).bind(this)}.bind(this));
+	st.on('pipe', function(chunk) {
+		log.debug("Stream PIPE event");
+		log.debug(chunk);
+	})
 	// Create the promise that resolves when the machining cycle ends.
 	var promise = this._createStatePromise([STAT_END]).then(function() {
 		this.context = null;

--- a/g2.js
+++ b/g2.js
@@ -212,6 +212,7 @@ G2.prototype._createCycleContext = function() {
 	st.on('data', function(chunk) {
 		// Stream data comes in "chunks" which are often multiple lines
 		chunk = chunk.toString();
+		log.debug('Data Chunk:  ' + chunk);
 		var newLines = false;
 		// Repartition incoming "chunked" data as lines
 		for(var i=0; i<chunk.length; i++) {

--- a/g2.js
+++ b/g2.js
@@ -171,6 +171,7 @@ function G2() {
 	this.flooded = false;
 	this.send_rate = 1;
 	this.lines_sent = 0;
+	this.primedThreshold = PRIMED_THRESHOLD;
 
 	this.context = null;
 
@@ -1038,10 +1039,11 @@ G2.prototype.waitForState = function(states) {
 // This allows us to run huge files from disk, or say, http, or from 
 // a stream processor that is streaming from one of those sources without
 // having to load the entire file into memory.
-G2.prototype.runStream = function(s, prime=false) {
+G2.prototype.runStream = function(s, manualPrime=false) {
 	log.info("from run stream to _createCycle")
 	this._createCycleContext();
-	if (prime) {
+	log.debug(manualPrime);
+	if (manualPrime) {
 		this.prime();
 	}
 	s.pipe(this.context._stream);

--- a/g2.js
+++ b/g2.js
@@ -260,7 +260,7 @@ G2.prototype._createCycleContext = function() {
 	// Handle a stream being piped into this context (currently do nothing)
 	st.on('pipe', function(chunk) {
 		log.debug("Stream PIPE event");
-		log.debug(chunk);
+		log.debug(chunk.toString());
 	})
 	// Create the promise that resolves when the machining cycle ends.
 	var promise = this._createStatePromise([STAT_END]).then(function() {

--- a/g2.js
+++ b/g2.js
@@ -232,7 +232,7 @@ G2.prototype._createCycleContext = function() {
 	}.bind(this));
 
 	// Set absolute, spindle speed default, units, and turn on output 4
-	////## TODO create default variable for S-value for VFD spindle control, just a dummy here now
+	// TODO: create default variable for S-value for VFD spindle control, just a dummy here now
 	st.write('G90\n ' + 'S1000\n ' + 'G61\n ' + 'M100 ({out4:1})\n ');
 
 	// Handle a stream finishing or disconnecting.
@@ -970,16 +970,17 @@ G2.prototype.command = function(obj) {
 // Send a (possibly multi-line) string
 // TODO - this function used to take a callback, but now does not.  
 //        Either implement it or drop it from the arguments list
-G2.prototype.runString = function(data, callback) {
-	var stringStream = new stream.Readable();
-	stringStream.push(data + "\n ");    ////## added space for reading
-	stringStream.push(null);
-	return this.runStream(stringStream);
-};
+//        Does not appear to be in use and can be removed?
+// G2.prototype.runString = function(data, callback) {
+// 	var stringStream = new stream.Readable();
+// 	stringStream.push(data + "\n ");    ////## added space for reading
+// 	stringStream.push(null);
+// 	return this.runStream(stringStream);
+// };
 
 // Works like runString above, but takes a list of lines instead of a string
-// TODO see above about callback
-G2.prototype.runList = function(l, callback) {
+// TODO:  Refactor could remove this.  See G2.prototype.setMachinePosition TODO.
+G2.prototype.runList = function(l) {
 	var stringStream = new stream.Readable();
 	for(var i=0; i<l.length; i++) {
 		stringStream.push(l[i] + "\n");
@@ -1039,17 +1040,18 @@ G2.prototype.runStream = function(s, manualPrime=false) {
 }
 
 // Run data from a file.  This is done with streams, which enjoy the benefits described in runStream above.
-G2.prototype.runFile = function(filename) {
-	var st = fs.createReadStream(filename);
-	var ln = new LineNumberer();
-	//return this.runStream(st);
-	return this.runStream(st.pipe(ln));
-}
+// TODO: Can be removed runtimes funnel direct to runStream
+// G2.prototype.runFile = function(filename) {
+// 	var st = fs.createReadStream(filename);
+// 	var ln = new LineNumberer();
+// 	//return this.runStream(st);
+// 	return this.runStream(st.pipe(ln));
+// }
 
-// TODO - Do we really need this function if we have runString?
-G2.prototype.runImmediate = function(data) {
-	return this.runString(data);
-}
+// TODO - Do we really need this function if we have runString?  Does not appear to be in use.
+// G2.prototype.runImmediate = function(data) {
+// 	return this.runString(data);
+// }
 
 // G2 begins running G-Codes as soon as it recieves them, and in certain cases, it is possible for
 // G2 to "plan to a stop" when this is not the desired behavior.  This typically happens at the start of
@@ -1131,6 +1133,7 @@ G2.prototype.setMachinePosition = function(position, callback) {
 	});
 
 	gcodes.push(this.status.unit === 'in' ? 'G20' : 'G21');
+	// TODO:  Refactor to use runstream directly
 	this.runList(gcodes).then(function() {callback && callback()})
 }
 

--- a/g2.js
+++ b/g2.js
@@ -1041,9 +1041,6 @@ G2.prototype.waitForState = function(states) {
 G2.prototype.runStream = function(s) {
 	log.info("from run stream to _createCycle")
 	this._createCycleContext();
-	s.on('data', (chunk) => {
-		log.debug('runstream chunk:  ' + chunk)
-	});
 	s.pipe(this.context._stream);
 	return this.context;
 }

--- a/g2.js
+++ b/g2.js
@@ -199,22 +199,11 @@ G2.prototype._createCycleContext = function() {
 	this._streamDone = false;
 	this.lineBuffer = []
 
-	////## added spaces after '\n's to make debug display easier to read
-	// TODO factor this out; ////## really???
-	// Inject a couple of G-Codes which are needed to start the machining cycle
-////##
-	// st.write('G90\n ' + 'S1000\n ' + 'G61\n ')  ////## AND, make sure we have a default S-value
-////## S-value needed for G2 spinup-delay to work (ugh!not M3 switch)
-////## TODO create default variable for S-value for VFD spindle control, just a dummy here now
-	// st.write('G90\n ' + 'G61\n ')  ////## to make sure we are not in exact stop mode left from fixed moves
-//	st.write('G90\n')
-	// st.write('M100 ({out4:1})\n ') // hack to get the "permissive relay" behavior while in-cycle
-////## v3 version of G2 is not yet "in cycle here"; an increasing problem!
 	// Handle data coming in on the stream
 	st.on('data', function(chunk) {
 		// Stream data comes in "chunks" which are often multiple lines
 		chunk = chunk.toString();
-		log.debug('Data Chunk:  ' + chunk);
+		// log.debug('Context on data Chunk:  ' + chunk);
 		var newLines = false;
 		// Repartition incoming "chunked" data as lines
 		for(var i=0; i<chunk.length; i++) {
@@ -230,7 +219,6 @@ G2.prototype._createCycleContext = function() {
 				// The G2 sender doesn't actually start sending until it is "primed"
 				// Priming happens either when the number of lines to send reaches a certain threshold
 				// or the prime() function is called manually.
-				// TODO:  Factor out 10 (magic number) and put it at the top of the file so it can be changed easily.
 				if(this.gcode_queue.getLength() >= PRIMED_THRESHOLD) {
 					this._primed = true;
 				}
@@ -244,6 +232,7 @@ G2.prototype._createCycleContext = function() {
 	}.bind(this));
 
 	// Set absolute, spindle speed default, units, and turn on output 4
+	////## TODO create default variable for S-value for VFD spindle control, just a dummy here now
 	st.write('G90\n ' + 'S1000\n ' + 'G61\n ' + 'M100 ({out4:1})\n ');
 
 	// Handle a stream finishing or disconnecting.
@@ -263,7 +252,6 @@ G2.prototype._createCycleContext = function() {
 	// Handle a stream being piped into this context (currently do nothing)
 	st.on('pipe', function(chunk) {
 		log.debug("Stream PIPE event");
-		log.debug(chunk.toString());
 	})
 	// Create the promise that resolves when the machining cycle ends.
 	var promise = this._createStatePromise([STAT_END]).then(function() {

--- a/g2.js
+++ b/g2.js
@@ -269,7 +269,7 @@ G2.prototype._createCycleContext = function() {
 	// 		this.sendMore();
 	// 	}
 	// }.bind(this));
-	st.on('data', processChunk(chunk).bind(this));
+	st.on('data', function(chunk) {processChunk(chunk).bind(this)}.bind(this));
 
 	// Set absolute, spindle speed default, units, and turn on output 4
 	st.write('G90\n ' + 'S1000\n ' + 'G61\n ' + 'M100 ({out4:1})\n ');
@@ -292,7 +292,7 @@ G2.prototype._createCycleContext = function() {
 	// st.on('pipe', function() {
 	// 	log.debug("Stream PIPE event");
 	// })
-	st.on('pipe', processChunk(chunk).bind(this))
+	st.on('pipe', function(chunk) {processChunk(chunk).bind(this)}.bind(this));
 	// Create the promise that resolves when the machining cycle ends.
 	var promise = this._createStatePromise([STAT_END]).then(function() {
 		this.context = null;

--- a/g2.js
+++ b/g2.js
@@ -1124,6 +1124,7 @@ G2.prototype.sendMore = function() {
 // position - An object mapping axes to position values. Axes that are not included will not be updated.
 G2.prototype.setMachinePosition = function(position, callback) {
 ////## until uvw enabled	var axes = ['x','y','z','a','b','c','u','v','w']
+	log.debug("### Set Machine Position ###");
 	var axes = ['x','y','z','a','b','c']
 	var gcodes = new stream.Readable();
 	gcodes.push('G21\n');
@@ -1135,7 +1136,8 @@ G2.prototype.setMachinePosition = function(position, callback) {
 
 	gcodes.push(this.status.unit === 'in' ? 'G20\n' : 'G21\n');
 	gcodes.push(null);
-	this.runStream(gcodes).then(function() {callback && callback()})
+	//TODO: Set manualPrime false once uvw enabled
+	this.runStream(gcodes, true).then(function() {callback && callback()})
 }
 
 // OLD VERSION Requires runList()

--- a/g2.js
+++ b/g2.js
@@ -1041,6 +1041,9 @@ G2.prototype.waitForState = function(states) {
 G2.prototype.runStream = function(s) {
 	log.info("from run stream to _createCycle")
 	this._createCycleContext();
+	s.on('data', (chunk) => {
+		log.debug('runstream chunk:  ' + chunk)
+	});
 	s.pipe(this.context._stream);
 	return this.context;
 }

--- a/g2.js
+++ b/g2.js
@@ -201,12 +201,12 @@ G2.prototype._createCycleContext = function() {
 	// TODO factor this out; ////## really???
 	// Inject a couple of G-Codes which are needed to start the machining cycle
 ////##
-	st.write('G90\n ' + 'S1000\n ' + 'G61\n ')  ////## AND, make sure we have a default S-value
+	// st.write('G90\n ' + 'S1000\n ' + 'G61\n ')  ////## AND, make sure we have a default S-value
 ////## S-value needed for G2 spinup-delay to work (ugh!not M3 switch)
 ////## TODO create default variable for S-value for VFD spindle control, just a dummy here now
-	st.write('G90\n ' + 'G61\n ')  ////## to make sure we are not in exact stop mode left from fixed moves
+	// st.write('G90\n ' + 'G61\n ')  ////## to make sure we are not in exact stop mode left from fixed moves
 //	st.write('G90\n')
-	st.write('M100 ({out4:1})\n ') // hack to get the "permissive relay" behavior while in-cycle
+	// st.write('M100 ({out4:1})\n ') // hack to get the "permissive relay" behavior while in-cycle
 ////## v3 version of G2 is not yet "in cycle here"; an increasing problem!
 	
 	// Handle data coming in on the stream
@@ -240,6 +240,9 @@ G2.prototype._createCycleContext = function() {
 			this.sendMore();
 		}
 	}.bind(this));
+
+	// Set absolute, spindle speed default, units, and turn on output 4
+	st.write('G90\n ' + 'S1000\n ' + 'G61\n ' + 'M100 ({out4:1})\n ');
 
 	// Handle a stream finishing or disconnecting.
 	st.on('end', function() {

--- a/g2.js
+++ b/g2.js
@@ -967,28 +967,6 @@ G2.prototype.command = function(obj) {
 	this.sendMore();
 };
 
-// Send a (possibly multi-line) string
-// TODO - this function used to take a callback, but now does not.  
-//        Either implement it or drop it from the arguments list
-//        Does not appear to be in use and can be removed?
-// G2.prototype.runString = function(data, callback) {
-// 	var stringStream = new stream.Readable();
-// 	stringStream.push(data + "\n ");    ////## added space for reading
-// 	stringStream.push(null);
-// 	return this.runStream(stringStream);
-// };
-
-// Works like runString above, but takes a list of lines instead of a string
-// TODO:  Refactor could remove this.  See G2.prototype.setMachinePosition TODO.
-// G2.prototype.runList = function(l) {
-// 	var stringStream = new stream.Readable();
-// 	for(var i=0; i<l.length; i++) {
-// 		stringStream.push(l[i] + "\n");
-// 	}
-// 	stringStream.push(null);
-// 	return this.runStream(stringStream);
-// }
-
 // Return a promise that resolves when one of the provided states is encountered
 // states - a list of states which will cause the promise to resolve
 // The promise resolves with the state that caused the resolution as an argument
@@ -1038,20 +1016,6 @@ G2.prototype.runStream = function(s, manualPrime=false) {
 	s.pipe(this.context._stream);
 	return this.context;
 }
-
-// Run data from a file.  This is done with streams, which enjoy the benefits described in runStream above.
-// TODO: Can be removed runtimes funnel direct to runStream
-// G2.prototype.runFile = function(filename) {
-// 	var st = fs.createReadStream(filename);
-// 	var ln = new LineNumberer();
-// 	//return this.runStream(st);
-// 	return this.runStream(st.pipe(ln));
-// }
-
-// TODO - Do we really need this function if we have runString?  Does not appear to be in use.
-// G2.prototype.runImmediate = function(data) {
-// 	return this.runString(data);
-// }
 
 // G2 begins running G-Codes as soon as it recieves them, and in certain cases, it is possible for
 // G2 to "plan to a stop" when this is not the desired behavior.  This typically happens at the start of
@@ -1124,7 +1088,6 @@ G2.prototype.sendMore = function() {
 // position - An object mapping axes to position values. Axes that are not included will not be updated.
 G2.prototype.setMachinePosition = function(position, callback) {
 ////## until uvw enabled	var axes = ['x','y','z','a','b','c','u','v','w']
-	log.debug("### Set Machine Position ###");
 	var axes = ['x','y','z','a','b','c']
 	var gcodes = new stream.Readable();
 	gcodes.push('G21\n');
@@ -1139,22 +1102,6 @@ G2.prototype.setMachinePosition = function(position, callback) {
 	//TODO: Set manualPrime false once uvw enabled
 	this.runStream(gcodes, true).then(function() {callback && callback()})
 }
-
-// OLD VERSION Requires runList()
-// G2.prototype.setMachinePosition = function(position, callback) {
-// ////## until uvw enabled	var axes = ['x','y','z','a','b','c','u','v','w']
-// 	var axes = ['x','y','z','a','b','c']
-// 	var gcodes = ['G21']
-// 	axes.forEach(function(axis) {
-// 		if(position[axis] != undefined) {
-// 			gcodes.push('G28.3 ' + axis + position[axis].toFixed(5));
-// 		}
-// 	});
-
-// 	gcodes.push(this.status.unit === 'in' ? 'G20' : 'G21');
-// 	// TODO:  Refactor to use runstream directly
-// 	this.runList(gcodes).then(function() {callback && callback()})
-// }
 
 // Function works like "once()" for a state change
 // callbacks is an associative array mapping states to callbacks

--- a/runtime/gcode/gcode.js
+++ b/runtime/gcode/gcode.js
@@ -208,7 +208,6 @@ GCodeRuntime.prototype.runString = function(string, callback) {
 	if(callback) { log.error("CALLBACK PASSED TO RUNSTRING")}
 
 	if(this.machine.status.state === 'idle' || this.machine.status.state === 'armed') {
-		
 		// count lines and set file length
 		var lines = (string.match(/\n/g) || '');
 		this.machine.status.nb_lines = lines.length;

--- a/runtime/gcode/gcode.js
+++ b/runtime/gcode/gcode.js
@@ -180,7 +180,8 @@ GCodeRuntime.prototype._handleStateChange = function(stat) {
 // Run a given stream input
 GCodeRuntime.prototype.runStream = function(st) {
 	var ln = new LineNumberer();
-	return this.driver.runStream(st.pipe(ln))
+	// return this.driver.runStream(st.pipe(ln))
+	return this.driver.runStream(st)
 		.on('stat', this._handleStateChange.bind(this))
 		.then(this._handleStop.bind(this));
 }
@@ -224,7 +225,6 @@ GCodeRuntime.prototype.runString = function(string, callback) {
 		// stringStream.on('data', (chunk) => {
 		// 	log.debug(chunk)
 		// });
-		this.driver.prime();
 		return this.runStream(stringStream);
 	}
 };

--- a/runtime/gcode/gcode.js
+++ b/runtime/gcode/gcode.js
@@ -180,7 +180,7 @@ GCodeRuntime.prototype._handleStateChange = function(stat) {
 // Run a given stream input
 GCodeRuntime.prototype.runStream = function(st) {
 	// check lines length and manually prime if below threshold value
-	if (this.machine.status.nb_lines < this.driver.PRIMED_THRESHHOLD){
+	if (this.machine.status.nb_lines < this.driver.PRIMED_THRESHOLD){
 		this.driver.prime();
 	};
 	var ln = new LineNumberer();

--- a/runtime/gcode/gcode.js
+++ b/runtime/gcode/gcode.js
@@ -204,9 +204,9 @@ GCodeRuntime.prototype.runString = function(string, callback) {
 
 	if(this.machine.status.state === 'idle' || this.machine.status.state === 'armed') {
 		// Add line numbers to Gcode string.
-		var lines = (string.match(/\n/g) || '').length + 1
-		// var lines =  string.split('\n');
-		this.machine.status.nb_lines = lines;
+		// var lines = (string.match(/\n/g) || '')
+		var lines =  string.split('\n');
+		this.machine.status.nb_lines = lines.length;
 		// for (i=0;i<lines.length;i++){
 		// 	if (lines[i][0]!==undefined && lines[i][0].toUpperCase() !== 'N' ){
 		// 		lines[i]= 'N'+ (i+1) + lines[i];
@@ -214,15 +214,15 @@ GCodeRuntime.prototype.runString = function(string, callback) {
 		// }
 		this.completeCallback = callback;
 		this._changeState("running");
-		var stringStream = stream.Readable.from(string);
-		stringStream.on('data', (chunk) => {
-			log.debug(chunk)
-		});
+		// var stringStream = stream.Readable.from(string);
+		// stringStream.on('data', (chunk) => {
+		// 	log.debug(chunk)
+		// });
 		// Push lines to stream.
-		// for(var i=0; i<lines.length; i++) {
-		// 	stringStream.push(lines[i] + "\n");
-		// }
-		// stringStream.push(null);
+		for(var i=0; i<lines.length; i++) {
+			stringStream.push(lines[i] + "\n");
+		}
+		stringStream.push(null);
 		return this.runStream(stringStream);
 	}
 };

--- a/runtime/gcode/gcode.js
+++ b/runtime/gcode/gcode.js
@@ -192,7 +192,7 @@ GCodeRuntime.prototype.runFile = function(filename, callback) {
 		countLineNumbers(filename, function(err, lines) {
 			this.machine.status.nb_lines = lines;
 			var st = fs.createReadStream(filename);
-			return this.runStream(st);
+			return this.runStream(st).bind(this);
 		}.bind(this));
 	}
 }
@@ -204,8 +204,8 @@ GCodeRuntime.prototype.runString = function(string, callback) {
 
 	if(this.machine.status.state === 'idle' || this.machine.status.state === 'armed') {
 		// Add line numbers to Gcode string.
-		// var lines = (string.match(/\n/g) || '')
-		var lines =  string.split('\n');
+		var lines = (string.match(/\n/g) || '');
+		// var lines =  string.split('\n');
 		this.machine.status.nb_lines = lines.length;
 		// for (i=0;i<lines.length;i++){
 		// 	if (lines[i][0]!==undefined && lines[i][0].toUpperCase() !== 'N' ){
@@ -214,16 +214,17 @@ GCodeRuntime.prototype.runString = function(string, callback) {
 		// }
 		this.completeCallback = callback;
 		this._changeState("running");
-		var stringStream = new stream.Readable();
-		// stringStream.on('data', (chunk) => {
-		// 	log.debug(chunk)
-		// });
+		// var stringStream = new stream.Readable();
 		// Push lines to stream.
-		for(var i=0; i<lines.length; i++) {
-			stringStream.push(lines[i] + "\n");
-		}
-		stringStream.push(null);
-		return this.runStream(stringStream);
+		// for(var i=0; i<lines.length; i++) {
+		// 	stringStream.push(lines[i] + "\n");
+		// }
+		// stringStream.push(null);
+		var stringStream = stream.Readable.from(string);
+		stringStream.on('data', (chunk) => {
+			log.debug(chunk)
+		});
+		return this.runStream(stringStream).bind(this);
 	}
 };
 

--- a/runtime/gcode/gcode.js
+++ b/runtime/gcode/gcode.js
@@ -214,7 +214,10 @@ GCodeRuntime.prototype.runString = function(string, callback) {
 		// }
 		this.completeCallback = callback;
 		this._changeState("running");
-		var stringStream = new stream.Readable.from(string);
+		var stringStream = stream.Readable.from(string);
+		stringStream.on('data', (chunk) => {
+			log.debug(chunk)
+		});
 		// Push lines to stream.
 		// for(var i=0; i<lines.length; i++) {
 		// 	stringStream.push(lines[i] + "\n");

--- a/runtime/gcode/gcode.js
+++ b/runtime/gcode/gcode.js
@@ -185,9 +185,9 @@ GCodeRuntime.prototype.runStream = function(st) {
 	};
 	var ln = new LineNumberer();
 	// return this.driver.runStream(st.pipe(ln))
-	return st.pipe(ln).pipe(this.driver.runStream()
+	return this.driver.runStream(st.pipe(ln).pipe(stream.Readable()))
 		.on('stat', this._handleStateChange.bind(this))
-		.then(this._handleStop.bind(this)));
+		.then(this._handleStop.bind(this));
 }
 
 // Run a file given the filename

--- a/runtime/gcode/gcode.js
+++ b/runtime/gcode/gcode.js
@@ -222,6 +222,7 @@ GCodeRuntime.prototype.runString = function(string, callback) {
 		this._changeState("running");
 		//convert string to stream and pass to streamRun
 		var stringStream = stream.Readable.from(string);
+		stringStream.push(null);
 		return this.runStream(stringStream);
 	}
 };

--- a/runtime/gcode/gcode.js
+++ b/runtime/gcode/gcode.js
@@ -179,6 +179,10 @@ GCodeRuntime.prototype._handleStateChange = function(stat) {
 
 // Run a given stream input
 GCodeRuntime.prototype.runStream = function(st) {
+	// check lines length and manually prime if below threshold value
+	if (this.machine.status.nb_lines < this.driver.PRIMED_THRESHHOLD){
+		this.driver.prime();
+	};
 	var ln = new LineNumberer();
 	// return this.driver.runStream(st.pipe(ln))
 	return this.driver.runStream(st)

--- a/runtime/gcode/gcode.js
+++ b/runtime/gcode/gcode.js
@@ -208,27 +208,18 @@ GCodeRuntime.prototype.runString = function(string, callback) {
 	if(callback) { log.error("CALLBACK PASSED TO RUNSTRING")}
 
 	if(this.machine.status.state === 'idle' || this.machine.status.state === 'armed') {
-		// Add line numbers to Gcode string.
+		// Ensure final endline
+		// string = string + "\n";
+		// count lines and set file length
 		var lines = (string.match(/\n/g) || '');
-		// var lines =  string.split('\n');
 		this.machine.status.nb_lines = lines.length;
-		// for (i=0;i<lines.length;i++){
-		// 	if (lines[i][0]!==undefined && lines[i][0].toUpperCase() !== 'N' ){
-		// 		lines[i]= 'N'+ (i+1) + lines[i];
-		// 	}
-		// }
+		
+		string = string + "\n";
+		// complete callback This should not be passed a callback but we complete it in case of legacy use.
 		this.completeCallback = callback;
 		this._changeState("running");
-		// var stringStream = new stream.Readable();
-		// Push lines to stream.
-		// for(var i=0; i<lines.length; i++) {
-		// 	stringStream.push(lines[i] + "\n");
-		// }
-		// stringStream.push(null);
+		//convert string to stream and pass to streamRun
 		var stringStream = stream.Readable.from(string);
-		// stringStream.on('data', (chunk) => {
-		// 	log.debug(chunk)
-		// });
 		return this.runStream(stringStream);
 	}
 };

--- a/runtime/gcode/gcode.js
+++ b/runtime/gcode/gcode.js
@@ -189,12 +189,12 @@ GCodeRuntime.prototype.runStream = function(st) {
 
 // Run a file given the filename
 GCodeRuntime.prototype.runFile = function(filename, callback) {
+	if(callback) { log.error("CALLBACK PASSED: gCode runFile")};
     this._file_or_stream_in_progress = true;
     if(this.machine.status.state === 'idle' || this.machine.status.state === 'armed') {
     	//  TODO:  Can we count line numbers before streaming without reading the file twice?
 		countLineNumbers(filename, function(err, lines) {
 			this.machine.status.nb_lines = lines;
-			// TODO:  
 			var st = fs.createReadStream(filename);
 			return this.runStream(st);
 		}.bind(this));
@@ -202,15 +202,13 @@ GCodeRuntime.prototype.runFile = function(filename, callback) {
 }
 
 // Run the provided string
-// callback runs only when execution is complete.
+// TODO: Should this all be incorporated with executeCode?
+//		Do we have any need for running gCode strings outside of the editor/job/macro system?
 GCodeRuntime.prototype.runString = function(string) {
 	if(this.machine.status.state === 'idle' || this.machine.status.state === 'armed') {
 		// count lines and set file length
 		var lines = (string.match(/\n/g) || '');
 		this.machine.status.nb_lines = lines.length;
-		// complete callback This should not be passed a callback but we complete it in case of legacy use.
-		// TODO: IS this needed here?
-		this._changeState("running");
 		//convert string to stream and pass to streamRun
 		var stringStream = stream.Readable.from(string);
 		return this.runStream(stringStream);
@@ -219,6 +217,7 @@ GCodeRuntime.prototype.runString = function(string) {
 
 // Run the given string as gcode
 GCodeRuntime.prototype.executeCode = function(string, callback) {
+	if(callback) { log.error("CALLBACK PASSED: gCode executeCode")};
 	this._file_or_stream_in_progress = true;
 	return this.runString(string);
 }

--- a/runtime/gcode/gcode.js
+++ b/runtime/gcode/gcode.js
@@ -185,7 +185,7 @@ GCodeRuntime.prototype.runStream = function(st) {
 	};
 	var ln = new LineNumberer();
 	// return this.driver.runStream(st.pipe(ln))
-	return this.driver.runStream(st.pipe(ln).pipe(stream.Readable()))
+	return this.driver.runStream(st.pipe(ln))
 		.on('stat', this._handleStateChange.bind(this))
 		.then(this._handleStop.bind(this));
 }

--- a/runtime/gcode/gcode.js
+++ b/runtime/gcode/gcode.js
@@ -214,7 +214,7 @@ GCodeRuntime.prototype.runString = function(string, callback) {
 		// }
 		this.completeCallback = callback;
 		this._changeState("running");
-		// var stringStream = stream.Readable.from(string);
+		var stringStream = new stream.Readable();
 		// stringStream.on('data', (chunk) => {
 		// 	log.debug(chunk)
 		// });

--- a/runtime/gcode/gcode.js
+++ b/runtime/gcode/gcode.js
@@ -149,37 +149,6 @@ GCodeRuntime.prototype._idle = function() {
 	}
 };
 
-// Run the provided string
-// callback runs only when execution is complete.
-GCodeRuntime.prototype.runString = function(string, callback) {
-	if(callback) { log.error("CALLBACK PASSED TO RUNSTRING")}
-
-	if(this.machine.status.state === 'idle' || this.machine.status.state === 'armed') {
-		// Add line numbers to Gcode string.
-		var lines =  string.split('\n');
-		this.machine.status.nb_lines = lines.length;
-		for (i=0;i<lines.length;i++){
-			if (lines[i][0]!==undefined && lines[i][0].toUpperCase() !== 'N' ){
-				lines[i]= 'N'+ (i+1) + lines[i];
-			}
-		}
-		// // Set absolute or incremental per config.
-		// var mode = config.driver.get('gdi') ? 'G91': 'G90';
-		// lines.unshift(mode);
-		this.completeCallback = callback;
-		this._changeState("running");
-		var stringStream = new stream.Readable();
-		// Push lines to stream.
-		for(var i=0; i<lines.length; i++) {
-			stringStream.push(lines[i] + "\n");
-		}
-		stringStream.push(null);
-		return this.driver.runStream(stringStream)
-		.on('stat', this._handleStateChange.bind(this))
-		.then(this._handleStop.bind(this));
-	}
-};
-
 GCodeRuntime.prototype._handleStop = function() {
 	this._idle();
 }
@@ -208,18 +177,52 @@ GCodeRuntime.prototype._handleStateChange = function(stat) {
 	}
 }
 
+// Run a given stream input
+GCodeRuntime.prototype.runStream = function(st) {
+	var ln = new LineNumberer();
+	return this.driver.runStream(st.pipe(ln))
+		.on('stat', this._handleStateChange.bind(this))
+		.then(this._handleStop.bind(this));
+}
+
 // Run a file given the filename
 GCodeRuntime.prototype.runFile = function(filename, callback) {
     this._file_or_stream_in_progress = true;
-	countLineNumbers(filename, function(err, lines) {
-		this.machine.status.nb_lines = lines;
-		var st = fs.createReadStream(filename);
-		var ln = new LineNumberer();
-		return this.driver.runStream(st.pipe(ln))
-			.on('stat', this._handleStateChange.bind(this))
-			.then(this._handleStop.bind(this));
-	}.bind(this));
+    if(this.machine.status.state === 'idle' || this.machine.status.state === 'armed') {
+		countLineNumbers(filename, function(err, lines) {
+			this.machine.status.nb_lines = lines;
+			var st = fs.createReadStream(filename);
+			return this.runStream(st);
+		}.bind(this));
+	}
 }
+
+// Run the provided string
+// callback runs only when execution is complete.
+GCodeRuntime.prototype.runString = function(string, callback) {
+	if(callback) { log.error("CALLBACK PASSED TO RUNSTRING")}
+
+	if(this.machine.status.state === 'idle' || this.machine.status.state === 'armed') {
+		// Add line numbers to Gcode string.
+		var lines = (string.match(/\n/g) || '').length + 1
+		// var lines =  string.split('\n');
+		this.machine.status.nb_lines = lines;
+		// for (i=0;i<lines.length;i++){
+		// 	if (lines[i][0]!==undefined && lines[i][0].toUpperCase() !== 'N' ){
+		// 		lines[i]= 'N'+ (i+1) + lines[i];
+		// 	}
+		// }
+		this.completeCallback = callback;
+		this._changeState("running");
+		var stringStream = new stream.Readable.from(string);
+		// Push lines to stream.
+		// for(var i=0; i<lines.length; i++) {
+		// 	stringStream.push(lines[i] + "\n");
+		// }
+		// stringStream.push(null);
+		return this.runStream(stringStream);
+	}
+};
 
 // Run the given string as gcode
 GCodeRuntime.prototype.executeCode = function(string, callback) {

--- a/runtime/gcode/gcode.js
+++ b/runtime/gcode/gcode.js
@@ -163,9 +163,9 @@ GCodeRuntime.prototype.runString = function(string, callback) {
 				lines[i]= 'N'+ (i+1) + lines[i];
 			}
 		}
-		// Set absolute or incremental per config.
-		var mode = config.driver.get('gdi') ? 'G91': 'G90';
-		lines.unshift(mode);
+		// // Set absolute or incremental per config.
+		// var mode = config.driver.get('gdi') ? 'G91': 'G90';
+		// lines.unshift(mode);
 		this.completeCallback = callback;
 		this._changeState("running");
 		var stringStream = new stream.Readable();

--- a/runtime/gcode/gcode.js
+++ b/runtime/gcode/gcode.js
@@ -222,7 +222,6 @@ GCodeRuntime.prototype.runString = function(string, callback) {
 		this._changeState("running");
 		//convert string to stream and pass to streamRun
 		var stringStream = stream.Readable.from(string);
-		stringStream.push(null);
 		return this.runStream(stringStream);
 	}
 };

--- a/runtime/gcode/gcode.js
+++ b/runtime/gcode/gcode.js
@@ -192,7 +192,7 @@ GCodeRuntime.prototype.runFile = function(filename, callback) {
 		countLineNumbers(filename, function(err, lines) {
 			this.machine.status.nb_lines = lines;
 			var st = fs.createReadStream(filename);
-			return this.runStream(st).bind(this);
+			return this.runStream(st);
 		}.bind(this));
 	}
 }
@@ -221,10 +221,11 @@ GCodeRuntime.prototype.runString = function(string, callback) {
 		// }
 		// stringStream.push(null);
 		var stringStream = stream.Readable.from(string);
-		stringStream.on('data', (chunk) => {
-			log.debug(chunk)
-		});
-		return this.runStream(stringStream).bind(this);
+		// stringStream.on('data', (chunk) => {
+		// 	log.debug(chunk)
+		// });
+		this.driver.prime();
+		return this.runStream(stringStream);
 	}
 };
 

--- a/runtime/gcode/gcode.js
+++ b/runtime/gcode/gcode.js
@@ -183,10 +183,13 @@ GCodeRuntime.prototype.runStream = function(st) {
 	// if (this.machine.status.nb_lines < this.driver.PRIMED_THRESHOLD){
 	// 	this.driver.prime();
 	// };
-	var prime = this.machine.status.nb_lines < this.driver.PRIMED_THRESHOLD
+	var manualPrime = this.machine.status.nb_lines < this.driver.primedThreshold;
+	log.debug(this.machine.status.nb_lines);
+	log.debug(this.driver.primedThreshold);
+	log.debug(manualPrime);
 	var ln = new LineNumberer();
 	// return this.driver.runStream(st.pipe(ln))
-	return this.driver.runStream(st.pipe(ln), prime)
+	return this.driver.runStream(st.pipe(ln), manualPrime)
 		.on('stat', this._handleStateChange.bind(this))
 		.then(this._handleStop.bind(this));
 }

--- a/runtime/gcode/gcode.js
+++ b/runtime/gcode/gcode.js
@@ -180,12 +180,13 @@ GCodeRuntime.prototype._handleStateChange = function(stat) {
 // Run a given stream input
 GCodeRuntime.prototype.runStream = function(st) {
 	// check lines length and manually prime if below threshold value
-	if (this.machine.status.nb_lines < this.driver.PRIMED_THRESHOLD){
-		this.driver.prime();
-	};
+	// if (this.machine.status.nb_lines < this.driver.PRIMED_THRESHOLD){
+	// 	this.driver.prime();
+	// };
+	var prime = this.machine.status.nb_lines < this.driver.PRIMED_THRESHOLD
 	var ln = new LineNumberer();
 	// return this.driver.runStream(st.pipe(ln))
-	return this.driver.runStream(st.pipe(ln))
+	return this.driver.runStream(st.pipe(ln), prime)
 		.on('stat', this._handleStateChange.bind(this))
 		.then(this._handleStop.bind(this));
 }

--- a/runtime/gcode/gcode.js
+++ b/runtime/gcode/gcode.js
@@ -185,9 +185,9 @@ GCodeRuntime.prototype.runStream = function(st) {
 	};
 	var ln = new LineNumberer();
 	// return this.driver.runStream(st.pipe(ln))
-	return st.pipe(ln).pipe(this.driver.runStream())
+	return st.pipe(ln).pipe(this.driver.runStream()
 		.on('stat', this._handleStateChange.bind(this))
-		.then(this._handleStop.bind(this));
+		.then(this._handleStop.bind(this)));
 }
 
 // Run a file given the filename

--- a/runtime/gcode/gcode.js
+++ b/runtime/gcode/gcode.js
@@ -185,7 +185,7 @@ GCodeRuntime.prototype.runStream = function(st) {
 	};
 	var ln = new LineNumberer();
 	// return this.driver.runStream(st.pipe(ln))
-	return this.driver.runStream(st)
+	return st.pipe(ln).pipe(this.driver.runStream())
 		.on('stat', this._handleStateChange.bind(this))
 		.then(this._handleStop.bind(this));
 }
@@ -208,13 +208,12 @@ GCodeRuntime.prototype.runString = function(string, callback) {
 	if(callback) { log.error("CALLBACK PASSED TO RUNSTRING")}
 
 	if(this.machine.status.state === 'idle' || this.machine.status.state === 'armed') {
-		// Ensure final endline
-		// string = string + "\n";
+		
 		// count lines and set file length
 		var lines = (string.match(/\n/g) || '');
 		this.machine.status.nb_lines = lines.length;
-		
-		string = string + "\n";
+		// Ensure final endline
+		// string = string + "\n";
 		// complete callback This should not be passed a callback but we complete it in case of legacy use.
 		this.completeCallback = callback;
 		this._changeState("running");

--- a/runtime/gcode/gcode.js
+++ b/runtime/gcode/gcode.js
@@ -191,8 +191,10 @@ GCodeRuntime.prototype.runStream = function(st) {
 GCodeRuntime.prototype.runFile = function(filename, callback) {
     this._file_or_stream_in_progress = true;
     if(this.machine.status.state === 'idle' || this.machine.status.state === 'armed') {
+    	//  TODO:  Can we count line numbers before streaming without reading the file twice?
 		countLineNumbers(filename, function(err, lines) {
 			this.machine.status.nb_lines = lines;
+			// TODO:  
 			var st = fs.createReadStream(filename);
 			return this.runStream(st);
 		}.bind(this));
@@ -201,15 +203,13 @@ GCodeRuntime.prototype.runFile = function(filename, callback) {
 
 // Run the provided string
 // callback runs only when execution is complete.
-GCodeRuntime.prototype.runString = function(string, callback) {
-	if(callback) { log.error("CALLBACK PASSED TO RUNSTRING")}
-
+GCodeRuntime.prototype.runString = function(string) {
 	if(this.machine.status.state === 'idle' || this.machine.status.state === 'armed') {
 		// count lines and set file length
 		var lines = (string.match(/\n/g) || '');
 		this.machine.status.nb_lines = lines.length;
 		// complete callback This should not be passed a callback but we complete it in case of legacy use.
-		this.completeCallback = callback;
+		// TODO: IS this needed here?
 		this._changeState("running");
 		//convert string to stream and pass to streamRun
 		var stringStream = stream.Readable.from(string);

--- a/runtime/gcode/gcode.js
+++ b/runtime/gcode/gcode.js
@@ -179,16 +179,9 @@ GCodeRuntime.prototype._handleStateChange = function(stat) {
 
 // Run a given stream input
 GCodeRuntime.prototype.runStream = function(st) {
-	// check lines length and manually prime if below threshold value
-	// if (this.machine.status.nb_lines < this.driver.PRIMED_THRESHOLD){
-	// 	this.driver.prime();
-	// };
+	//determine if this is a short stream and needs to manually prime
 	var manualPrime = this.machine.status.nb_lines < this.driver.primedThreshold;
-	log.debug(this.machine.status.nb_lines);
-	log.debug(this.driver.primedThreshold);
-	log.debug(manualPrime);
 	var ln = new LineNumberer();
-	// return this.driver.runStream(st.pipe(ln))
 	return this.driver.runStream(st.pipe(ln), manualPrime)
 		.on('stat', this._handleStateChange.bind(this))
 		.then(this._handleStop.bind(this));
@@ -215,8 +208,6 @@ GCodeRuntime.prototype.runString = function(string, callback) {
 		// count lines and set file length
 		var lines = (string.match(/\n/g) || '');
 		this.machine.status.nb_lines = lines.length;
-		// Ensure final endline
-		// string = string + "\n";
 		// complete callback This should not be passed a callback but we complete it in case of legacy use.
 		this.completeCallback = callback;
 		this._changeState("running");

--- a/util.js
+++ b/util.js
@@ -545,6 +545,8 @@ util.inherits(LineNumberer, stream.Transform);
 
 LineNumberer.prototype._transform = function(chunk, enc, next) {
   var data = chunk.toString();
+  log.debug('transform chunk:  ' + chunk);
+  log.debug('transform string:  ' + data);
   if (this._lastLineData) { data = this._lastLineData + data; }
 
   var lines = data.split('\n');

--- a/util.js
+++ b/util.js
@@ -555,7 +555,7 @@ LineNumberer.prototype._transform = function(chunk, enc, next) {
     //this.push("N" + this.count + " " + lines[i] + '\n');
     block.push("N" + this.count + " " + lines[i]);
   }
-
+  log.debug('lineNumber block:  ' + block);
   this.push(block.join('\n'))
   next();
 };

--- a/util.js
+++ b/util.js
@@ -539,6 +539,7 @@ function LineNumberer(options) {
   this.start = true;
   this.input = "";
   this.output = "";
+  // We start with lastChar as a newline to start each stream with a line number.
   this.lastChar = "\n";
   // init Transform
   stream.Transform.call(this, options);
@@ -547,7 +548,8 @@ util.inherits(LineNumberer, stream.Transform);
 
 LineNumberer.prototype._transform = function(chunk, enc, next) {
     this.input = chunk.toString();
-    log.debug("input:  " + this.input);
+    // log.debug("input:  " + this.input);
+    // Walk the input chunk and add new line number after each newline
     for (const c of this.input) {
         if (this.lastChar == "\n") {
             this.count += 1;
@@ -558,15 +560,15 @@ LineNumberer.prototype._transform = function(chunk, enc, next) {
         }
         this.lastChar = c
     }
-    log.debug("output:  " + this.output);
+    // log.debug("output:  " + this.output);
     this.push(this.output);
     this.output = "";
     next();
 }
 
 LineNumberer.prototype._flush = function(done) {
+    // Ensure we end with a new line so the final line is sent.
     this.push("\n");
-    this.push(null)
     done()
 }
 

--- a/util.js
+++ b/util.js
@@ -535,11 +535,11 @@ function LineNumberer(options) {
   if (!(this instanceof LineNumberer)) {
     return new LineNumberer(options);
   }
-  this.count = 1;
+  this.count = 0;
   this.start = true;
   this.input = "";
   this.output = "";
-  this.lastChar = "";
+  this.lastChar = "\n";
   // init Transform
   stream.Transform.call(this, options);
 }
@@ -549,18 +549,12 @@ LineNumberer.prototype._transform = function(chunk, enc, next) {
     this.input = chunk.toString();
     log.debug("input:  " + this.input);
     for (const c of this.input) {
-        if (this.start) {
-            this.output = (c == "N") ? "" : "N1 ";
+        if (this.lastChar == "\n") {
+            this.count += 1;
+            this.output += (c == "N") ? "" : "N" + this.count + " ";
             this.output += c;
-            this.start = false;
         } else {
-            if (this.lastChar == "\n") {
-                this.count += 1;
-                this.output += (c == "N") ? "" : "N" + this.count + " ";
-                this.output += c;
-            } else {
-                this.output += c;
-            }
+            this.output += c;
         }
         this.lastChar = c
     }
@@ -571,6 +565,7 @@ LineNumberer.prototype._transform = function(chunk, enc, next) {
 
 LineNumberer.prototype._flush = function(done) {
     this.push("\n");
+    this.push(null)
     done()
 }
 

--- a/util.js
+++ b/util.js
@@ -545,8 +545,6 @@ util.inherits(LineNumberer, stream.Transform);
 
 LineNumberer.prototype._transform = function(chunk, enc, next) {
   var data = chunk.toString();
-  log.debug('transform chunk:  ' + chunk);
-  log.debug('transform string:  ' + data);
   if (this._lastLineData) { data = this._lastLineData + data; }
 
   var lines = data.split('\n');
@@ -557,7 +555,7 @@ LineNumberer.prototype._transform = function(chunk, enc, next) {
     //this.push("N" + this.count + " " + lines[i] + '\n');
     block.push("N" + this.count + " " + lines[i]);
   }
-  // log.debug('lineNumber block:  ' + block);
+  log.debug('lineNumber block:  ' + block.join('\n'));
   this.push(block.join('\n'))
   next();
 };

--- a/util.js
+++ b/util.js
@@ -549,7 +549,7 @@ util.inherits(LineNumberer, stream.Transform);
 LineNumberer.prototype._transform = function(chunk, enc, next) {
     this.input = chunk.toString();
     // log.debug("input:  " + this.input);
-    // Walk the input chunk and add new line number after each newline
+    // Walk the input chunk and add new line number after each newline if line number is not present
     for (const c of this.input) {
         if (this.lastChar == "\n") {
             this.count += 1;

--- a/util.js
+++ b/util.js
@@ -539,6 +539,7 @@ function LineNumberer(options) {
   this.start = true;
   this.input = "";
   this.output = "";
+  this.lastChar = "";
   // init Transform
   stream.Transform.call(this, options);
 }
@@ -547,16 +548,21 @@ util.inherits(LineNumberer, stream.Transform);
 LineNumberer.prototype._transform = function(chunk, enc, next) {
     this.input = chunk.toString();
     log.debug("input:  " + this.input);
-    if (this.start) {
-        this.output = "N" + this.count + " " + this.input;
-        this.start = false;
-    } else {
-        if (input == "\n") {
-            this.count += 1;
-            this.output = this.input + "N" + this.count + " ";
+    for (const c of this.input) {
+        if (this.start) {
+            this.output = (c == "N") ? "" : "N1 ";
+            this output += c;
+            this.start = false;
         } else {
-            this.output = this.input;
+            if (this.lastChar == "\n") {
+                this.count += 1;
+                this.output += (c == "N") ? "" : "N" + this.count + " ";
+                this.output += c;
+            } else {
+                this.output += c;
+            }
         }
+        this.lastChar = c
     }
     log.debug("output:  " + this.output);
     this.push(this.output);

--- a/util.js
+++ b/util.js
@@ -572,29 +572,6 @@ LineNumberer.prototype._flush = function(done) {
     done()
 }
 
-// LineNumberer.prototype._transform = function(chunk, enc, next) {
-//   var data = chunk.toString();
-//   if (this._lastLineData) { data = this._lastLineData + data; }
-
-//   var lines = data.split('\n');
-//   this._lastLineData = lines.splice(lines.length-1,1)[0];
-//   block = []
-//   for(var i=0; i<lines.length; i++) {
-//     this.count += 1;
-//     //this.push("N" + this.count + " " + lines[i] + '\n');
-//     block.push("N" + this.count + " " + lines[i]);
-//   }
-//   log.debug('lineNumber block:  ' + block.join('\n'));
-//   this.push(block.join('\n'));
-//   next();
-// };
-
-// LineNumberer.prototype._flush = function(done) {
-//   if (this._lastLineData) { this.push("N" + this.count + " " + this._lastLineData + "\n"); }
-//   this._lastLineData = null;
-//   done();
-// };
-
 var countLineNumbers = function(filename, callback) {
     var i;
     var lines = 0;

--- a/util.js
+++ b/util.js
@@ -561,7 +561,7 @@ LineNumberer.prototype._transform = function(chunk, enc, next) {
 };
 
 LineNumberer.prototype._flush = function(done) {
-  if (this._lastLineData) { this.push(this._lastLineData); }
+  if (this._lastLineData) { this.push("N" + this.count + " " + this._lastLineData + "\n"); }
   this._lastLineData = null;
   done();
 };

--- a/util.js
+++ b/util.js
@@ -551,7 +551,7 @@ LineNumberer.prototype._transform = function(chunk, enc, next) {
     for (const c of this.input) {
         if (this.start) {
             this.output = (c == "N") ? "" : "N1 ";
-            this output += c;
+            this.output += c;
             this.start = false;
         } else {
             if (this.lastChar == "\n") {

--- a/util.js
+++ b/util.js
@@ -555,7 +555,7 @@ LineNumberer.prototype._transform = function(chunk, enc, next) {
     //this.push("N" + this.count + " " + lines[i] + '\n');
     block.push("N" + this.count + " " + lines[i]);
   }
-  log.debug('lineNumber block:  ' + block);
+  // log.debug('lineNumber block:  ' + block);
   this.push(block.join('\n'))
   next();
 };

--- a/util.js
+++ b/util.js
@@ -556,7 +556,7 @@ LineNumberer.prototype._transform = function(chunk, enc, next) {
     block.push("N" + this.count + " " + lines[i]);
   }
   log.debug('lineNumber block:  ' + block.join('\n'));
-  this.push(block.join('\n'))
+  this.push(block.join('\n') + "\n");
   next();
 };
 

--- a/util.js
+++ b/util.js
@@ -560,6 +560,7 @@ LineNumberer.prototype._transform = function(chunk, enc, next) {
     }
     log.debug("output:  " + this.output);
     this.push(this.output);
+    this.output = "";
     next();
 }
 


### PR DESCRIPTION
Refactor g2.js createCycleContext to more cleanly insert default prepend values into the stream on start.

Refactor gcode runtime to handle file and string gcode the same and pass it into g2.js runStream function and allow for runStream to manually prime if needed.

Remove all runFile, runString, and runList functionality from g2.js to rely on runStream. update setMachinePosition to use runStream and correctly manually prime.

Rewrite utils lineNumberer stream transform to correctly number lines when lines are unnumbered and keep the stream feed steady.
