### PR TITLE
Make SBP variables case insensitive

### DIFF
--- a/runtime/opensbp/sbp_parser.js
+++ b/runtime/opensbp/sbp_parser.js
@@ -1615,7 +1615,7 @@ module.exports = (function(){
           pos = pos1;
         }
         if (result0 !== null) {
-          result0 = (function(offset, v) {return {"type":"user_variable", "expr":v.join("")}})(pos0, result0);
+          result0 = (function(offset, v) {return {"type":"user_variable", "expr":v.join("").toUpperCase()}})(pos0, result0);
         }
         if (result0 === null) {
           pos = pos0;
@@ -1651,7 +1651,7 @@ module.exports = (function(){
           pos = pos1;
         }
         if (result0 !== null) {
-          result0 = (function(offset, v) {return {"type":"persistent_variable", "expr":v.join("")}})(pos0, result0);
+          result0 = (function(offset, v) {return {"type":"persistent_variable", "expr":v.join("").toUpperCase()}})(pos0, result0);
         }
         if (result0 === null) {
           pos = pos0;

--- a/runtime/opensbp/sbp_parser.pegjs
+++ b/runtime/opensbp/sbp_parser.pegjs
@@ -98,10 +98,10 @@ variable
   = (user_variable / system_variable / persistent_variable)
 
 user_variable
-  = v:("&" identifier) {return {"type":"user_variable", "expr":v.join("")}}
+  = v:("&" identifier) {return {"type":"user_variable", "expr":v.join("").toUpperCase()}}
 
 persistent_variable
-  = v:("$" identifier ) {return {"type":"persistent_variable", "expr":v.join("")}}
+  = v:("$" identifier ) {return {"type":"persistent_variable", "expr":v.join("").toUpperCase()}}
 
 system_variable
   = "%" "(" __ e:expression __ ")" {return {"type":"system_variable", "expr":e}}


### PR DESCRIPTION
Eliminate case sensitivity in user variables and persistent variabls 
(i.e. variables of the form &myVariable and $anotheRvariable)
By internally converting all references to use the fully capitalized version.

An arbitrary test file that was rejected and is now processed correctly by the parser:

SA
M3, 0, 0, 0
$YPOS=1
&counter = %($YpOS) + 4
MX, &cOunteR
MY, &CounTer
M3, 0, 0, 0

FYI this file is nonsense, except as a test case - the names don't mean what they seem to mean and the motion isn't particularly useful.