### PR TITLE
Addresses work item 36: label case sensitivity

### DIFF
--- a/runtime/opensbp/sbp_parser.js
+++ b/runtime/opensbp/sbp_parser.js
@@ -1130,7 +1130,7 @@ module.exports = (function(){
           pos = pos1;
         }
         if (result0 !== null) {
-          result0 = (function(offset, cmd, lbl) {return {type:cmd.toLowerCase(), label:lbl};})(pos0, result0[0], result0[2]);
+          result0 = (function(offset, cmd, lbl) {return {type:cmd.toLowerCase(), label:lbl.toUpperCase()};})(pos0, result0[0], result0[2]);
         }
         if (result0 === null) {
           pos = pos0;
@@ -1306,7 +1306,7 @@ module.exports = (function(){
           pos = pos1;
         }
         if (result0 !== null) {
-          result0 = (function(offset, id) {return {type:"label", value:id};})(pos0, result0[0]);
+          result0 = (function(offset, id) {return {type:"label", value:id.toUpperCase()};})(pos0, result0[0]);
         }
         if (result0 === null) {
           pos = pos0;

--- a/runtime/opensbp/sbp_parser.pegjs
+++ b/runtime/opensbp/sbp_parser.pegjs
@@ -67,7 +67,7 @@ open
 jump
    = cmd:("GOTO"i / "GOSUB"i) ___ 
      lbl:identifier 
-     {return {type:cmd.toLowerCase(), label:lbl};}
+     {return {type:cmd.toLowerCase(), label:lbl.toUpperCase()};}
 
 argument
    = (float / integer / expression / barestring / quotedstring / "")
@@ -78,7 +78,7 @@ identifier
    = id:([a-zA-Z_]+[A-Za-z0-9_]*) {return id[0].join("") + id[1].join(""); }
 
 label
-   = id:identifier ":" {return {type:"label", value:id};}
+   = id:identifier ":" {return {type:"label", value:id.toUpperCase()};}
 
 decimal
   = digits:[0-9]+ { return digits.join(""); }


### PR DESCRIPTION
Takes care of case changes in both the label and the reference to the label
in a goto or gosub jump. It solves it for both absolute
goto/gosub and for goto/gosub in the "then" clause a conditional.
Test case in the worksheet now passes, as well as several variants.