### PR TITLE
item 34 - commutivity in args to cmds

### DIFF
--- a/runtime/opensbp/sbp_parser.js
+++ b/runtime/opensbp/sbp_parser.js
@@ -1141,11 +1141,11 @@ module.exports = (function(){
       function parse_argument() {
         var result0;
         
-        result0 = parse_float();
+        result0 = parse_e1();
         if (result0 === null) {
-          result0 = parse_integer();
+          result0 = parse_float();
           if (result0 === null) {
-            result0 = parse_e1();
+            result0 = parse_integer();
             if (result0 === null) {
               result0 = parse_barestring();
               if (result0 === null) {

--- a/runtime/opensbp/sbp_parser.pegjs
+++ b/runtime/opensbp/sbp_parser.pegjs
@@ -70,7 +70,7 @@ jump
      {return {type:cmd.toLowerCase(), label:lbl};}
 
 argument
-   = (float / integer / expression / barestring / quotedstring / "")
+   = (expression / float / integer / barestring / quotedstring / "")
 
 mnemonic = code: ([_A-Za-z][_A-Za-z0-9\#]) {return code.join('').replace('#','_POUND');}
 


### PR DESCRIPTION
When the arguments to a command comprise and expression AND
the expression starts with an integer or float, the integer
or float should not need to be enclosed in parens.

This is a small change. I tested quite a few variations around the problem case, 
but I worry that there may be other implications.

the important thing here is that unlike context free grammars that expose ambiguities which then have to be 
disambiguated in code, Parser Expressioin Grammars (PEGs) go with the first match. In this case, the  harder match 
is an expression rather than an int or a float or a string, so by moving the "expression" match ahead of the others, we 
exhaust attempting to match a full expression before giving up and trying an integer or float or string. 

What I wonder is were there any other aspects of the grammar that depended on the existing order, or was it just arbitrary from simplest to more complex (sort of the opposite of what you want in a PEG). So any addiional testing of the language would be 
great.