### PR TITLE
49724 quit pause restart

### DIFF
--- a/dashboard/static/js/main.js
+++ b/dashboard/static/js/main.js
@@ -273,7 +273,12 @@ require("../css/toastr.min.css");
                                 detail: detailHTML,
                                 cancelText: status.state === 'dead' ? undefined : 'Quit',
                                 cancel: status.state === 'dead' ? undefined : function() {
-                                    dashboard.engine.quit();
+                                    dashboard.engine.quit(function(err, result) {
+                                                            if (err) {
+                                                              console.log("ERRROR: " + err);
+                                                            }
+                                                        }
+                                                    );
                                 }
                             });
                             modalIsShown = true;
@@ -289,7 +294,12 @@ require("../css/toastr.min.css");
                             cancelText: 'Quit',
                             cancel: function() {
                                 authorizeDialog = false;
-                                dashboard.engine.quit();
+                                dashboard.engine.quit(function(err, result) {
+                                                            if (err) {
+                                                              console.log("ERRROR: " + err);
+                                                            }
+                                                        }
+                                                    );
                             }
           
                         });
@@ -303,7 +313,12 @@ require("../css/toastr.min.css");
                             cancelText: 'Quit',
                             cancel: function() {
                                 interlockDialog = false;
-                                dashboard.engine.quit();
+                                dashboard.engine.quit(function(err, result) {
+                                                            if (err) {
+                                                              console.log("ERRROR: " + err);
+                                                            }
+                                                        }
+                                                    );
                             },
 
                             okText: 'Resume',

--- a/g2.js
+++ b/g2.js
@@ -768,11 +768,12 @@ G2.prototype.quit = function() {
 	if(this.stream) {
 		this.stream.end()
 	}
-	// Clear the gcodes we have queued up
-	this.gcode_queue.clear();
-	// Issue the actual Job Kill
-    log.debug("Sending Cleanup KILL"); ////##
-	this._write('\x04\n');
+	// Clear queues
+	this.queueFlush(function() {
+		// Issue the actual Job Kill
+	    log.debug("Sending Cleanup KILL"); ////##
+		this._write('\x04\n');
+	});
 }
 
 // Old Version:  TODO: Remove after refactor

--- a/g2.js
+++ b/g2.js
@@ -764,25 +764,43 @@ G2.prototype.quit = function() {
 		return;
 	}
 
-	switch(this.status.stat) {
-		//case STAT_END:
-		//	return;
-		//	break;
-
-		default:
-			this.quit_pending = true;
-
-			if(this.stream) {
-				this.stream.end()
-			}
-			// Clear the gcodes we have queued up
-			this.gcode_queue.clear();
-			// Issue the actual Job Kill
-            log.debug("Sending Cleanup KILL"); ////##
-			this._write('\x04\n');
-			break;
+	this.quit_pending = true;
+	if(this.stream) {
+		this.stream.end()
 	}
+	// Clear the gcodes we have queued up
+	this.gcode_queue.clear();
+	// Issue the actual Job Kill
+    log.debug("Sending Cleanup KILL"); ////##
+	this._write('\x04\n');
 }
+
+// Old Version:  TODO: Remove after refactor
+// G2.prototype.quit = function() {
+// 	if(this.quit_pending) {
+// 		log.warn("Not quitting because a quit is already pending.");
+// 		return;
+// 	}
+
+// 	switch(this.status.stat) {
+// 		//case STAT_END:
+// 		//	return;
+// 		//	break;
+
+// 		default:
+// 			this.quit_pending = true;
+
+// 			if(this.stream) {
+// 				this.stream.end()
+// 			}
+// 			// Clear the gcodes we have queued up
+// 			this.gcode_queue.clear();
+// 			// Issue the actual Job Kill
+//             log.debug("Sending Cleanup KILL"); ////##
+// 			this._write('\x04\n');
+// 			break;
+// 	}
+// }
 
 // When the gcode runtime asks that an M30 be sent, send it. This is pulled out from the
 //  normal queuing and writing path because of a timing issue with the g2core that needs to be

--- a/g2.js
+++ b/g2.js
@@ -774,6 +774,9 @@ G2.prototype.quit = function() {
 		// Issue the actual Job Kill
 	    log.debug("Sending Cleanup KILL"); ////##
 		this._write('\x04\n');
+		//Finally clear context and _reset primed flag so we're not reliant on getting a stat 4 to clear the context.
+		this.context = null;
+		this._primed = false;
 	});
 }
 

--- a/g2.js
+++ b/g2.js
@@ -237,6 +237,7 @@ G2.prototype._createCycleContext = function() {
 
 	// Handle a stream finishing or disconnecting.
 	st.on('end', function() {
+		log.debug('cycle context end event')
 		// Send whatever is left in the queue.  (There may be stuff unsent even after the stream is over)
 		this._primed = true;
 		this._streamDone = true;

--- a/g2.js
+++ b/g2.js
@@ -768,7 +768,7 @@ G2.prototype.quit = function() {
 	if(this.stream) {
 		this.stream.end()
 	}
-	// Clear queues
+	// Clear queues then issue kill.
 	this.queueFlush(function() {
 		// Issue the actual Job Kill
 	    log.debug("Sending Cleanup KILL"); ////##

--- a/g2.js
+++ b/g2.js
@@ -780,33 +780,6 @@ G2.prototype.quit = function() {
 	});
 }
 
-// Old Version:  TODO: Remove after refactor
-// G2.prototype.quit = function() {
-// 	if(this.quit_pending) {
-// 		log.warn("Not quitting because a quit is already pending.");
-// 		return;
-// 	}
-
-// 	switch(this.status.stat) {
-// 		//case STAT_END:
-// 		//	return;
-// 		//	break;
-
-// 		default:
-// 			this.quit_pending = true;
-
-// 			if(this.stream) {
-// 				this.stream.end()
-// 			}
-// 			// Clear the gcodes we have queued up
-// 			this.gcode_queue.clear();
-// 			// Issue the actual Job Kill
-//             log.debug("Sending Cleanup KILL"); ////##
-// 			this._write('\x04\n');
-// 			break;
-// 	}
-// }
-
 // When the gcode runtime asks that an M30 be sent, send it. This is pulled out from the
 //  normal queuing and writing path because of a timing issue with the g2core that needs to be
 //  resolved. Right now, when the g2core runs out of gcode in the buffer, it seems like it

--- a/machine.js
+++ b/machine.js
@@ -915,37 +915,40 @@ Machine.prototype.pause = function(callback) {
 
 // Quit 
 Machine.prototype.quit = function(callback) {
-		// Release Pause hold if present
-		this.driver.pause_hold = false;
-		this.disarm();
+	// Release Pause hold if present
+	this.driver.pause_hold = false;
+	this.disarm();
 
-		// Quitting from the idle state dismisses the 'info' data
-		switch(this.status.state) {
+	// Quitting from the idle state dismisses the 'info' data
+	switch(this.status.state) {
 
-			case "idle":
-				delete this.status.info;
-				this.emit('status', this.status);
-				break;
+		case "idle":
+			delete this.status.info;
+			this.emit('status', this.status);
+			break;
 
-			case "interlock":
-				this.action = null;
-				this.setState(this, 'idle');
-				break;
-		}
-	
-		// Cancel the currently running job, if there is one
-		if(this.status.job) {
-			this.status.job.pending_cancel = true;
-		}
-		if(this.current_runtime) {
-			log.info("Quitting the current runtime...")
-			this.current_runtime.quit();
+		case "interlock":
+			this.action = null;
+			this.setState(this, 'idle');
+			break;
+	}
+	// Cancel the currently running job, if there is one
+	if(this.status.job) {
+		this.status.job.pending_cancel = true;
+	}
+	if(this.current_runtime) {
+		log.info("Quitting the current runtime...")
+		this.current_runtime.quit();
+		if (callback) {
 			callback(null, 'quit');
-			alreadyQuiting = false;
-		} else {
-			log.warn("No current runtime!")
+		}
+		alreadyQuiting = false;
+	} else {
+		log.warn("No current runtime!")
+		if (callback) {
 			callback("Not quiting because no current runtime")
-		}    
+		}
+	}
 };
 
 // Resume from the paused state.

--- a/runtime/gcode/gcode.js
+++ b/runtime/gcode/gcode.js
@@ -188,8 +188,7 @@ GCodeRuntime.prototype.runStream = function(st) {
 }
 
 // Run a file given the filename
-GCodeRuntime.prototype.runFile = function(filename, callback) {
-	if(callback) { log.error("CALLBACK PASSED: gCode runFile")};
+GCodeRuntime.prototype.runFile = function(filename) {
     this._file_or_stream_in_progress = true;
     if(this.machine.status.state === 'idle' || this.machine.status.state === 'armed') {
     	//  TODO:  Can we count line numbers before streaming without reading the file twice?
@@ -216,8 +215,7 @@ GCodeRuntime.prototype.runString = function(string) {
 };
 
 // Run the given string as gcode
-GCodeRuntime.prototype.executeCode = function(string, callback) {
-	if(callback) { log.error("CALLBACK PASSED: gCode executeCode")};
+GCodeRuntime.prototype.executeCode = function(string) {
 	this._file_or_stream_in_progress = true;
 	return this.runString(string);
 }

--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -246,7 +246,7 @@ SBPRuntime.prototype.needsAuth = function(s) {
 // TODO At the very least, this function should simply take the string provided and stream it into runStream - they do the same thing.
 //          s - The string to run
 //   callback - Called when the program has ended 
-SBPRuntime.prototype.runString = function(sk) {
+SBPRuntime.prototype.runString = function(s) {
     try {
         // Break the string into lines
         var lines =  s.split('\n');

--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -935,7 +935,7 @@ SBPRuntime.prototype._abort = function(error) {
 // This restores the state of both the runtime and the driver, and sets the machine state appropriately
 //   error - (optional) If the program is ending due to an error, this is it.  Can be string or error object.
 SBPRuntime.prototype._end = function(error) {
-    
+    log.debug("runtime _end() called");
     // debug info
     log.stack();
 
@@ -944,21 +944,14 @@ SBPRuntime.prototype._end = function(error) {
     if(!error) {
         error = this.end_message || null;
     }
-    log.debug("Calling the non-nested (toplevel) end");
-
-    // TODO:  User Vars now stored on config and persistent is this functionality still needed?
-    // // Delete the user variables that don't stick around across runs
-    // for(var key in this.user_vars) {
-    //     if(key[1] === '_') {
-    //         delete this.user_vars[key]
-    //     }
-    // }  
-
     // Log the error for posterity
     if(error) {log.error(error)}
 
+    log.debug("Calling the non-nested (toplevel) end");
+
     // Cleanup deals the "final blow" - cleans up streams, sets the machine state and calls the end callback
     var cleanup = function(error) {
+        log.debug("_end Cleanup called");
         log.stack()
         if(this.machine && error) {
             this.machine.setState(this, 'stopped', {'error' : error });
@@ -966,52 +959,114 @@ SBPRuntime.prototype._end = function(error) {
         if(!this.machine){
             this.stream.end();
         }
-        this.ok_to_disconnect = true;
+        // Clear the internal state of the runtime (restore it to its initial state)
+        this.init();
         this.emit('end', this);
         if(this.end_callback) {
             this.end_callback();
         }
     }.bind(this);
 
-    // Clear the internal state of the runtime (restore it to its initial state)
-    this.init();
 
-    // TODO - this big complicated if-else can probably be collapsed to something simpler with some
-    //      rearranging and changing of the cleanup() function above (or maybe it can be eliminated??)
-    if(error) {
-        if(this.machine) {
-            this.resumeAllowed = false;
-            this.machine.restoreDriverState(function(err, result) {
-                this.resumeAllowed = true;
-                cleanup(error);
-            }.bind(this));
-        } else {
+    if(this.machine) {
+        this.resumeAllowed=false
+        this.machine.restoreDriverState(function(err, result) {
+            this.resumeAllowed = true;
+            if(this.machine.status.job) {
+                this.machine.status.job.finish(function(err, job) {
+                    this.machine.status.job=null;
+                    this.machine.setState(this, 'idle');
+                }.bind(this));
+            } else {
+                this.driver.setUnits(config.machine.get('units'), function() {
+                    this.machine.setState(this, 'idle');
+                }.bind(this));
+            }
             cleanup(error);
-        }
-        // TODO - Shouldn't this deal with the currently running job (if it exists)
-        //        as is done below?? this.machine.status.job.fail maybe?
+        }.bind(this));
     } else {
-        if(this.machine) {
-            this.resumeAllowed=false
-            this.machine.restoreDriverState(function(err, result) {
-                this.resumeAllowed = true;
-                if(this.machine.status.job) {
-                    this.machine.status.job.finish(function(err, job) {
-                        this.machine.status.job=null;
-                        this.machine.setState(this, 'idle');
-                    }.bind(this));
-                } else {
-                    this.driver.setUnits(config.machine.get('units'), function() {
-                        this.machine.setState(this, 'idle');
-                    }.bind(this));
-                }
-                cleanup();
-            }.bind(this));
-        } else {
-            cleanup();
-        }
+        cleanup(error);
     }
 };
+// Old Version:  TODO: remove after Refactor
+// SBPRuntime.prototype._end = function(error) {
+
+//     // debug info
+//     log.stack();
+
+//     // Normalize the error and ending state
+//     error = error ? error.message || error : null;
+//     if(!error) {
+//         error = this.end_message || null;
+//     }
+//     log.debug("Calling the non-nested (toplevel) end");
+
+//     // TODO:  User Vars now stored on config and persistent is this functionality still needed?
+//     // // Delete the user variables that don't stick around across runs
+//     // for(var key in this.user_vars) {
+//     //     if(key[1] === '_') {
+//     //         delete this.user_vars[key]
+//     //     }
+//     // }  
+
+//     // Log the error for posterity
+//     if(error) {log.error(error)}
+
+//     // Cleanup deals the "final blow" - cleans up streams, sets the machine state and calls the end callback
+//     var cleanup = function(error) {
+//         log.stack()
+//         if(this.machine && error) {
+//             this.machine.setState(this, 'stopped', {'error' : error });
+//         }
+//         if(!this.machine){
+//             this.stream.end();
+//         }
+//         this.ok_to_disconnect = true;
+//         this.emit('end', this);
+//         if(this.end_callback) {
+//             this.end_callback();
+//         }
+//     }.bind(this);
+
+//     // Clear the internal state of the runtime (restore it to its initial state)
+//     this.init();
+
+//     // TODO - this big complicated if-else can probably be collapsed to something simpler with some
+//     //      rearranging and changing of the cleanup() function above (or maybe it can be eliminated??)
+//     if(error) {
+//         if(this.machine) {
+//             this.resumeAllowed = false;
+//             this.machine.restoreDriverState(function(err, result) {
+//                 this.resumeAllowed = true;
+//                 cleanup(error);
+//             }.bind(this));
+//         } else {
+//             cleanup(error);
+//         }
+//         // TODO - Shouldn't this deal with the currently running job (if it exists)
+//         //        as is done below?? this.machine.status.job.fail maybe?
+//     } else {
+//         if(this.machine) {
+//             this.resumeAllowed=false
+//             this.machine.restoreDriverState(function(err, result) {
+//                 this.resumeAllowed = true;
+//                 if(this.machine.status.job) {
+//                     this.machine.status.job.finish(function(err, job) {
+//                         this.machine.status.job=null;
+//                         this.machine.setState(this, 'idle');
+//                     }.bind(this));
+//                 } else {
+//                     this.driver.setUnits(config.machine.get('units'), function() {
+//                         this.machine.setState(this, 'idle');
+//                     }.bind(this));
+//                 }
+//                 cleanup();
+//             }.bind(this));
+//         } else {
+//             cleanup();
+//         }
+//     }
+// };
 
 // Execute the specified command
 //    command - The command object to execute
@@ -1990,17 +2045,29 @@ SBPRuntime.prototype.pause = function() {
 // Quit the currently running program
 // If the machine is currently moving it will be stopped immediately and the program abandoned
 SBPRuntime.prototype.quit = function() {
-    if(this.ok_to_disconnect) {
-        return this._end();
-    }
-
-    if(this.machine.status.state == 'stopped' || this.machine.status.state == 'paused') {
-        this.machine.driver.quit();
-    } else {
-        this.quit_pending = true;
-        this.driver.quit();
-    }
+    log.debug('OpenSBP runtime Quit');
+    //  Send Quit to g2.js driver.
+    log.debug("issueing driver quit");
+    this.driver.quit();
+    log.debug("driver quit issued");
+    // Teardown runtime.
+    log.debug("runtime quit(): begin teardown");
+    this._end();
+    log.debug("runtime quit(): teardown complete")
 }
+// Old Version: TODO: Remove once refactor complete
+// SBPRuntime.prototype.quit = function() {
+//     if(this.ok_to_disconnect) {
+//         return this._end();
+//     }
+
+//     if(this.machine.status.state == 'stopped' || this.machine.status.state == 'paused') {
+//         this.machine.driver.quit();
+//     } else {
+//         this.quit_pending = true;
+//         this.driver.quit();
+//     }
+// }
 
 // Resume a program from the paused state
 //   TODO - make some indication that this action was successfil (resume is not always allowed, and sometimes it fails)

--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -950,9 +950,10 @@ SBPRuntime.prototype._end = function(error) {
         if(this.machine && error) {
             this.machine.setState(this, 'stopped', {'error' : error });
         }
-        if(!this.machine){
-            this.stream.end();
-        }
+        // if(!this.machine){
+        //     this.stream.end();
+        // }
+        this.stream.end();
         this.emit('end', this);
         // Clear the internal state of the runtime (restore it to its initial state)
         this.init();
@@ -967,13 +968,14 @@ SBPRuntime.prototype._end = function(error) {
                 this.machine.status.job.finish(function(err, job) {
                     this.machine.status.job=null;
                     this.machine.setState(this, 'idle');
+                    cleanup(error);
                 }.bind(this));
             } else {
                 this.driver.setUnits(config.machine.get('units'), function() {
                     this.machine.setState(this, 'idle');
+                    cleanup(error);
                 }.bind(this));
             }
-            cleanup(error);
         }.bind(this));
     } else {
         cleanup(error);

--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -959,12 +959,12 @@ SBPRuntime.prototype._end = function(error) {
         if(!this.machine){
             this.stream.end();
         }
-        // Clear the internal state of the runtime (restore it to its initial state)
-        this.init();
         this.emit('end', this);
         if(this.end_callback) {
             this.end_callback();
         }
+        // Clear the internal state of the runtime (restore it to its initial state)
+        this.init();
     }.bind(this);
 
 
@@ -2046,14 +2046,16 @@ SBPRuntime.prototype.pause = function() {
 // If the machine is currently moving it will be stopped immediately and the program abandoned
 SBPRuntime.prototype.quit = function() {
     log.debug('OpenSBP runtime Quit');
-    //  Send Quit to g2.js driver.
-    log.debug("issueing driver quit");
-    this.driver.quit();
-    log.debug("driver quit issued");
+
     // Teardown runtime.
     log.debug("runtime quit(): begin teardown");
     this._end();
     log.debug("runtime quit(): teardown complete")
+
+    //  Send Quit to g2.js driver.
+    log.debug("issueing driver quit");
+    this.driver.quit();
+    log.debug("driver quit issued");
 }
 // Old Version: TODO: Remove once refactor complete
 // SBPRuntime.prototype.quit = function() {

--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -959,7 +959,7 @@ SBPRuntime.prototype._end = function(error) {
         this.init();
     }.bind(this);
 
-
+    // TODO:  Is all this needed here?  Do we need to reset state?  Can this be done without nested callbacks?
     if(this.machine) {
         this.resumeAllowed=false
         this.machine.restoreDriverState(function(err, result) {
@@ -2033,6 +2033,8 @@ SBPRuntime.prototype.pause = function() {
 SBPRuntime.prototype.quit = function() {
     log.debug('OpenSBP runtime Quit');
 
+    //TODO: Not sure order matters but I think we want to teardown the runtime and close the stream first.
+    //      Should driver quit be a callback?
     // Teardown runtime.
     log.debug("runtime quit(): begin teardown");
     this._end();

--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -2046,16 +2046,15 @@ SBPRuntime.prototype.pause = function() {
 // If the machine is currently moving it will be stopped immediately and the program abandoned
 SBPRuntime.prototype.quit = function() {
     log.debug('OpenSBP runtime Quit');
+    //  Send Quit to g2.js driver.
+    log.debug("issueing driver quit");
+    this.driver.quit();
+    log.debug("driver quit issued");
 
     // Teardown runtime.
     log.debug("runtime quit(): begin teardown");
     this._end();
     log.debug("runtime quit(): teardown complete")
-
-    //  Send Quit to g2.js driver.
-    log.debug("issueing driver quit");
-    this.driver.quit();
-    log.debug("driver quit issued");
 }
 // Old Version: TODO: Remove once refactor complete
 // SBPRuntime.prototype.quit = function() {


### PR DESCRIPTION
This update cleans up the stop/quit chain and includes a fix to ensure that the runtime, cycle_context, and driver (g2.js) all are correctly torn down and ready for the next run.  It also includes some fixes for stray missing and outdated callbacks.

With this update quit from feedhold as well as from programmatic stop should both complete without relying on stat 4 returning from g2 to complete the teardown of the cycle context or runtime.