### PR TITLE
refs #50195 remove spaces inserted in commit 69a4f6ec30e96

### DIFF
--- a/g2.js
+++ b/g2.js
@@ -248,7 +248,7 @@ G2.prototype._createCycleContext = function() {
     ////## TODO: fix this kludge to get the current_runtime !
 	if (global.CUR_RUNTIME !=  "[IdleRuntime]") {
 		log.debug("PREPEND to cycle - " + global.CUR_RUNTIME)	
-		st.write('N1 G90\n ' + 'N2 S1000\n ' + 'N3 G61\n ' + 'N4 M100 ({out4:1})\n ' + 'N5 M0\n ');
+		st.write('N1 G90\n' + 'N2 S1000\n' + 'N3 G61\n' + 'N4 M100 ({out4:1})\n' + 'N5 M0\n');
 	}
 
 	// Handle a stream finishing or disconnecting.
@@ -1111,7 +1111,7 @@ G2.prototype.sendMore = function() {
 		var codes = this.command_queue.multiDequeue(count)
 		codes.push("");
 		this._ignored_responses+=to_send;
-		this._write(codes.join('\n '), function() {});
+		this._write(codes.join('\n'), function() {});
 	}
 
 	// If we're primed, go ahead and send more g-codes
@@ -1126,7 +1126,7 @@ G2.prototype.sendMore = function() {
 					codes.push(""); 
 					if(codes.length > 1) {
 						this.lines_to_send -= to_send/*-offset*/;
-						this._write(codes.join('\n '), function() { });
+						this._write(codes.join('\n'), function() { });
 				}
 			}
 		}

--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -1847,7 +1847,7 @@ SBPRuntime.prototype.emit_gcode = function(s) {
     var gcode = 'N' + temp_n + ' ' + s; 
     log.debug('Writing to stream in emit_gcode: ' + gcode);
     log.debug("emit_gcode: " + gcode);
-    gcode = gcode + '\n ';
+    gcode = gcode + '\n';
     this.stream.write(gcode);
 };
 


### PR DESCRIPTION
removing spaces from the strings sent to g2 solves that issue with delayed or duplicate pauses being inserted into the stream.  I believe space may trigger some kind of internal drain or flush for G2core this branch removes the spaces inserted previously and in my testing allows both the simple circle file and shopbot logo to run with multiple programatic and manual pauses and resumes as expected as well as pause and quit.