### PR TITLE
refs #49545 track timestamps on server only.

### DIFF
--- a/dashboard/static/js/libs/fabmoui.js
+++ b/dashboard/static/js/libs/fabmoui.js
@@ -271,7 +271,7 @@ FabMoUI.prototype.updateStatusContent = function(status){
 
 	//Current File or job
 	if(status.job) {
-	    var time_in_ms = Date.now()-status.job.started_at;
+	    var time_in_ms = status.server_ts-status.job.started_at;
         var time_elapsed_ms = time_in_ms % 1000;
         var time_in_s = Math.floor(time_in_ms /1000);
         var time_elapsed_s = time_in_s % 60;

--- a/routes/websocket.js
+++ b/routes/websocket.js
@@ -61,6 +61,8 @@ function setupStatusBroadcasts(server){
 	machine.on('status',function(status){
 //		console.log('Status broadcast');
 //		console.log(JSON.stringify(status));
+		//Add Server Timestamp to status updates
+		status.server_ts = Date.now();
 		server.io.of('/private').sockets.forEach(function (socket) {
 			if(status.state === 'idle' || status.state != previous_status.state) {
 				socket.emit('status',status);


### PR DESCRIPTION
Insert server timestamp on all outgoing status messages to clients to allow all timer calculations to be based on server time.