### PR TITLE
refs #50469 Set paused by user state only on timed pause 

### DIFF
--- a/machine.js
+++ b/machine.js
@@ -923,8 +923,10 @@ Machine.prototype.pause = function(callback) {
 			if (this.pauseTimer) {
 				clearTimeout(this.pauseTimer);
 				this.pauseTimer = false;
+				this.setState(this, 'paused', {'message': "Paused by user."});
+			} else {
+				this.current_runtime.pause();
 			}
-			this.setState(this, 'paused', {'message': "Paused by user."});
 			callback(null, 'paused');
 		} else {
 			callback("Not pausing because machine is not running");


### PR DESCRIPTION
This will prevent race conditions from triggering the paused by user dialog when a pause is issued after a probe command inside a loop.