### PR TITLE
refs #50564 cleanup before setting state.

### DIFF
--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -954,12 +954,12 @@ SBPRuntime.prototype._end = function(error) {
             if(this.machine.status.job) {
                 this.machine.status.job.finish(function(err, job) {
                     this.machine.status.job=null;
-                    this.machine.setState(this, 'idle');
                     cleanup(error);
+                    this.machine.setState(this, 'idle');
                 }.bind(this));
             } else {
-                this.machine.setState(this, 'idle');
                 cleanup(error);
+                this.machine.setState(this, 'idle');
             }
         }.bind(this));
     } else {


### PR DESCRIPTION
Looks like we were doing cleanup out of order and not setting ok to disconnect before changing state.  That has been corrected and seems to have resolved the error and allows the manual keypad to be used reliably.