### PR TITLE
50769 pause so

### DIFF
--- a/dashboard/static/js/libs/fabmoapi.js
+++ b/dashboard/static/js/libs/fabmoapi.js
@@ -79,6 +79,8 @@ FabMoAPI.prototype._initializeWebsocket = function() {
 
 	if(this.socket) {
 		this.socket.on('status', function(status) {
+			console.log("50769 on status fabmoapi");
+			console.log(status)
 			this._setStatus(status);
 			this.emit('status', status);
 		}.bind(this));
@@ -160,6 +162,8 @@ FabMoAPI.prototype.emit = function(evt, data) {
 }
 
 FabMoAPI.prototype.on = function(message, func) {
+	console.log("50769 fabmoapi on");
+	console.log(message);
 	if(message in this.events) {
 		this.events[message].push(func);
 	}

--- a/dashboard/static/js/libs/fabmoapi.js
+++ b/dashboard/static/js/libs/fabmoapi.js
@@ -79,7 +79,6 @@ FabMoAPI.prototype._initializeWebsocket = function() {
 
 	if(this.socket) {
 		this.socket.on('status', function(status) {
-			console.log("50769 on status fabmoapi");
 			console.log(status)
 			this._setStatus(status);
 			this.emit('status', status);
@@ -162,8 +161,6 @@ FabMoAPI.prototype.emit = function(evt, data) {
 }
 
 FabMoAPI.prototype.on = function(message, func) {
-	console.log("50769 fabmoapi on");
-	console.log(message);
 	if(message in this.events) {
 		this.events[message].push(func);
 	}

--- a/dashboard/static/js/main.js
+++ b/dashboard/static/js/main.js
@@ -221,7 +221,8 @@ require("../css/toastr.min.css");
                     }
 
                     if (status['info'] && status['info']['id'] != lastInfoSeen) {
-                        console.log("50769 status.info:  "+status['info']);
+                        console.log("50769 status.info ");
+                        console.log(status['info']);
                         lastInfoSeen = status['info']['id'];
                         if (status.info['message']) {
                             if(status.state ==="manual"){

--- a/dashboard/static/js/main.js
+++ b/dashboard/static/js/main.js
@@ -200,11 +200,14 @@ require("../css/toastr.min.css");
                         case 'running':
                         case 'paused':
                         case 'stopped':
+                            console.log("50769 runnning/paused/stop switch hit");
+                            console.log("50769 modal is shown:  "+modalIsShown);
                             if(modalIsShown === false) {
                                 dashboard.handlers.showFooter();
                             }
                             break;
                         default:
+                            console.log("50769 state switch default");
                             dashboard.handlers.hideFooter();
                             break;
                     }
@@ -218,6 +221,7 @@ require("../css/toastr.min.css");
                     }
 
                     if (status['info'] && status['info']['id'] != lastInfoSeen) {
+                        console.log("50769 status.info:  "+status['info']);
                         lastInfoSeen = status['info']['id'];
                         if (status.info['message']) {
                             if(status.state ==="manual"){

--- a/dashboard/static/js/main.js
+++ b/dashboard/static/js/main.js
@@ -200,14 +200,11 @@ require("../css/toastr.min.css");
                         case 'running':
                         case 'paused':
                         case 'stopped':
-                            console.log("50769 runnning/paused/stop switch hit");
-                            console.log("50769 modal is shown:  "+modalIsShown);
                             if(modalIsShown === false) {
                                 dashboard.handlers.showFooter();
                             }
                             break;
                         default:
-                            console.log("50769 state switch default");
                             dashboard.handlers.hideFooter();
                             break;
                     }
@@ -221,8 +218,6 @@ require("../css/toastr.min.css");
                     }
 
                     if (status['info'] && status['info']['id'] != lastInfoSeen) {
-                        console.log("50769 status.info ");
-                        console.log(status['info']);
                         lastInfoSeen = status['info']['id'];
                         if (status.info['message']) {
                             if(status.state ==="manual"){

--- a/machine.js
+++ b/machine.js
@@ -975,7 +975,11 @@ Machine.prototype.resume = function(callback, input=false) {
 			'type' : 'resume',
 			'input' : input
 		}, config.machine.get('auth_timeout'));
-    	callback(null, 'resumed');
+		if (callback) {
+	    	callback(null, 'resumed');
+	    } else {
+	    	log.debug('Undefined callback passed to resume');
+	    }
 	}
 }
 

--- a/machine.js
+++ b/machine.js
@@ -848,7 +848,9 @@ Machine.prototype.setState = function(source, newstate, stateinfo) {
 
 				break;
 			case 'paused':
+				log.debug("50764 set state paused");
                 if(this.status.state != newstate) {
+                	log.debug("50769 state != newstate");
                 	//set driver in paused state
                 	this.driver.pause_hold = true;
                 	// Save the position to the instance configuration.  See note above.
@@ -879,6 +881,8 @@ Machine.prototype.setState = function(source, newstate, stateinfo) {
 	} else {
 		log.warn("Got a state change from a runtime that's not the current one. (" + source + ")")
 	}
+	log.debug("50769 emiting state:  " + JSON.stringify(this.status.state));
+	log.debug("50769 emiting info:  " + JSON.stringify(this.status.info));
 	this.emit('status',this.status);
 	if (this.status.info && this.status.info['timer']){
 		this.pauseTimer = setTimeout(function() {

--- a/machine.js
+++ b/machine.js
@@ -848,9 +848,7 @@ Machine.prototype.setState = function(source, newstate, stateinfo) {
 
 				break;
 			case 'paused':
-				log.debug("50764 set state paused");
                 if(this.status.state != newstate) {
-                	log.debug("50769 state != newstate");
                 	//set driver in paused state
                 	this.driver.pause_hold = true;
                 	// Save the position to the instance configuration.  See note above.
@@ -881,8 +879,6 @@ Machine.prototype.setState = function(source, newstate, stateinfo) {
 	} else {
 		log.warn("Got a state change from a runtime that's not the current one. (" + source + ")")
 	}
-	log.debug("50769 emiting state:  " + JSON.stringify(this.status.state));
-	log.debug("50769 emiting info:  " + JSON.stringify(this.status.info));
 	this.emit('status',this.status);
 	if (this.status.info && this.status.info['timer']){
 		this.pauseTimer = setTimeout(function() {

--- a/routes/websocket.js
+++ b/routes/websocket.js
@@ -59,20 +59,28 @@ function setupAuthentication(svr) {
 function setupStatusBroadcasts(server){
 	var previous_status = {'state':null}
 	machine.on('status',function(status){
+		log.debug("50769 websocket on status listener");
+		log.debug(JSON.stringify(status));
 		//Add Server Timestamp to status updates
 		status.server_ts = Date.now();
 		server.io.of('/private').sockets.forEach(function (socket) {
+			log.debug("private sockets");
 			if(status.state === 'idle' || status.state != previous_status.state) {
+				log.debug("standard emit");
 				socket.emit('status',status);
 			} else {
+				log.debug("volatile emit");
 				socket.volatile.emit('status', status);
 			}
 		});
 
 		server.io.sockets.sockets.forEach(function (socket) {
+			log.debug("all sockets");
 			if(status.state === 'idle' || status.state != previous_status.state) {
+				log.debug("standard emit");
 				socket.emit('status',status);
 			} else {
+				log.debug("volatile emit");
 				socket.volatile.emit('status', status);
 			}
 		});

--- a/routes/websocket.js
+++ b/routes/websocket.js
@@ -59,28 +59,20 @@ function setupAuthentication(svr) {
 function setupStatusBroadcasts(server){
 	var previous_status = {'state':null}
 	machine.on('status',function(status){
-		log.debug("50769 websocket on status listener");
-		log.debug(JSON.stringify(status));
 		//Add Server Timestamp to status updates
 		status.server_ts = Date.now();
 		server.io.of('/private').sockets.forEach(function (socket) {
-			log.debug("private sockets");
-			if(status.state === 'idle' || status.state != previous_status.state) {
-				log.debug("standard emit");
+			if(status.state === 'idle' || status.state === 'paused' || status.state != previous_status.state) {
 				socket.emit('status',status);
 			} else {
-				log.debug("volatile emit");
 				socket.volatile.emit('status', status);
 			}
 		});
 
 		server.io.sockets.sockets.forEach(function (socket) {
-			log.debug("all sockets");
-			if(status.state === 'idle' || status.state != previous_status.state) {
-				log.debug("standard emit");
+			if(status.state === 'idle' || status.state === 'paused' || status.state != previous_status.state) {
 				socket.emit('status',status);
 			} else {
-				log.debug("volatile emit");
 				socket.volatile.emit('status', status);
 			}
 		});

--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -1185,9 +1185,11 @@ SBPRuntime.prototype._execute = function(command, callback) {
             break;
 
         case "pause":
+            log.debug("50764 pause command");
             // PAUSE is somewhat overloaded.  In a perfect world there would be distinct states for pause and feedhold.
             this.pc += 1;
             var arg = this._eval(command.expr);
+            log.debug("50769 arg = "+arg)
             var var_name = command.var;
             if(util.isANumber(arg)) {
                 // If argument is a number set pause with timer and default message.
@@ -1207,7 +1209,9 @@ SBPRuntime.prototype._execute = function(command, callback) {
                 }
                 // If a message is provided, pause with a dialog
                 var message = arg;
+                log.debug("50769 message = "+message);
                 if(!message) {
+                    log.debug("50769 no message");
                     // If a message is not provided, use the comment from the previous line
                     var last_command = this.program[this.pc-2];
                     if(last_command && last_command.type === 'comment') {

--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -1189,7 +1189,6 @@ SBPRuntime.prototype._execute = function(command, callback) {
             // PAUSE is somewhat overloaded.  In a perfect world there would be distinct states for pause and feedhold.
             this.pc += 1;
             var arg = this._eval(command.expr);
-            log.debug("50769 arg = "+arg)
             var var_name = command.var;
             if(util.isANumber(arg)) {
                 // If argument is a number set pause with timer and default message.
@@ -1209,9 +1208,7 @@ SBPRuntime.prototype._execute = function(command, callback) {
                 }
                 // If a message is provided, pause with a dialog
                 var message = arg;
-                log.debug("50769 message = "+message);
                 if(!message) {
-                    log.debug("50769 no message");
                     // If a message is not provided, use the comment from the previous line
                     var last_command = this.program[this.pc-2];
                     if(last_command && last_command.type === 'comment') {


### PR DESCRIPTION
Adds exception for pause to broadcaststatusupdates not to use volatile emit even on back to back pause status updates.  This ensures all pause updates are sent to the client in the correct order and will not be dropped solving the issue of pausing not updating client side after a non-move opensbp action such as an SO.