### PR TITLE
refs #50863 remove the option for volatile emits.

### DIFF
--- a/routes/websocket.js
+++ b/routes/websocket.js
@@ -57,26 +57,16 @@ function setupAuthentication(svr) {
 }
 
 function setupStatusBroadcasts(server){
-	var previous_status = {'state':null}
 	machine.on('status',function(status){
 		//Add Server Timestamp to status updates
 		status.server_ts = Date.now();
 		server.io.of('/private').sockets.forEach(function (socket) {
-			if(status.state === 'idle' || status.state === 'paused' || status.state != previous_status.state) {
-				socket.emit('status',status);
-			} else {
-				socket.volatile.emit('status', status);
-			}
+			socket.emit('status',status);
 		});
 
 		server.io.sockets.sockets.forEach(function (socket) {
-			if(status.state === 'idle' || status.state === 'paused' || status.state != previous_status.state) {
-				socket.emit('status',status);
-			} else {
-				socket.volatile.emit('status', status);
-			}
+			socket.emit('status',status);
 		});
-		previous_status.state = status.state;
 	});
 
 	machine.on('change', function(topic) {


### PR DESCRIPTION
This completely removes volatile emits from the websocket ensuring no status updates are dropped due to connection uptime or related conditions.  