### PR TITLE
51846 pause input

### DIFF
--- a/dashboard/build/index.html
+++ b/dashboard/build/index.html
@@ -438,6 +438,7 @@
           </div>
           <div class="modalInput">
             <input type="hidden" id="inputVar"/>
+            <input type="hidden" id="inputType"/>
             <input type="text" id="inputVal" class="inputVal" />
             <p class="inputError">Please Enter a Valid Value.</p>
           </div>

--- a/dashboard/static/js/dashboard.js
+++ b/dashboard/static/js/dashboard.js
@@ -1063,7 +1063,8 @@ define(function(require) {
     }
 
     if (options['input']) {
-        $('#inputVar').val(options['input']);
+        $('#inputVar').val(options['input']['name']);
+        $('#inputType').val(options['input']['type']);
         $('.modalInput').show();
     } else {
         $('.modalInput').hide();

--- a/dashboard/static/js/main.js
+++ b/dashboard/static/js/main.js
@@ -247,7 +247,7 @@ require("../css/toastr.min.css");
                                         var inputVar = $('#inputVar').val();
                                         var inputType = $('#inputType').val();
                                         var inputVal = $.trim($('#inputVal').val());
-                                        dashboard.engine.resume({'var': inputVar, 'type': inputType 'val': inputVal});
+                                        dashboard.engine.resume({'var': inputVar, 'type': inputType, 'val': inputVal});
                                         //  TODO: stop modal from closing on click so we can validate.
                                         // if(inputVal != '') {
                                         //     $('.inputError').hide();

--- a/dashboard/static/js/main.js
+++ b/dashboard/static/js/main.js
@@ -245,8 +245,9 @@ require("../css/toastr.min.css");
                                     modalOptions['input'] = status['info']['input'];
                                     modalOptions['ok'] = function() {
                                         var inputVar = $('#inputVar').val();
+                                        var inputType = $('#inputType').val();
                                         var inputVal = $.trim($('#inputVal').val());
-                                        dashboard.engine.resume({'var': inputVar, 'val': inputVal});
+                                        dashboard.engine.resume({'var': inputVar, 'type': inputType 'val': inputVal});
                                         //  TODO: stop modal from closing on click so we can validate.
                                         // if(inputVal != '') {
                                         //     $('.inputError').hide();

--- a/machine.js
+++ b/machine.js
@@ -467,7 +467,7 @@ Machine.prototype.arm = function(action, timeout) {
 
 	// Otherwise, arm the machine and set the timer to the provided value
 	log.info("Arming the machine" + (action ? (' for ' + action.type) : '(No action)'));
-	if action.type == 'resume' {
+	if (action.type == 'resume') {
 		log.debug('#51846 arm resume action: ' + JSON.stringify(action))
 	}
 	//log.error(new Error())

--- a/machine.js
+++ b/machine.js
@@ -467,9 +467,6 @@ Machine.prototype.arm = function(action, timeout) {
 
 	// Otherwise, arm the machine and set the timer to the provided value
 	log.info("Arming the machine" + (action ? (' for ' + action.type) : '(No action)'));
-	if (action.type == 'resume') {
-		log.debug('#51846 arm resume action: ' + JSON.stringify(action))
-	}
 	//log.error(new Error())
 	if(this._armTimer) { clearTimeout(this._armTimer);}
 	this._armTimer = setTimeout(function() {

--- a/machine.js
+++ b/machine.js
@@ -467,6 +467,9 @@ Machine.prototype.arm = function(action, timeout) {
 
 	// Otherwise, arm the machine and set the timer to the provided value
 	log.info("Arming the machine" + (action ? (' for ' + action.type) : '(No action)'));
+	if action.type == 'resume' {
+		log.debug('#51846 arm resume action: ' + JSON.stringify(action))
+	}
 	//log.error(new Error())
 	if(this._armTimer) { clearTimeout(this._armTimer);}
 	this._armTimer = setTimeout(function() {
@@ -959,6 +962,7 @@ Machine.prototype.quit = function(callback) {
 
 // Resume from the paused state.
 Machine.prototype.resume = function(callback, input=false) {
+	log.debug('#52846 machine resume input: ' + JSON.stringify(input))
 	if (this.driver.pause_hold) {
 		//Release driver pause hold
 		this.driver.pause_hold = false;

--- a/routes/websocket.js
+++ b/routes/websocket.js
@@ -165,6 +165,7 @@ var onPrivateConnect = function(socket) {
 					break;
 
 				case 'resume':
+					log.debug('#51846 websocket resume data: ' + JSON.stringify(data))
 					if (data.args && data.args.var && data.args.val) {
 						machine.resume(callback, {'var':data.args.var, 'val':data.args.val});
 					}

--- a/routes/websocket.js
+++ b/routes/websocket.js
@@ -165,7 +165,6 @@ var onPrivateConnect = function(socket) {
 					break;
 
 				case 'resume':
-					log.debug('#51846 websocket resume data: ' + JSON.stringify(data))
 					if (data.args && data.args.var && data.args.type && data.args.val) {
 						machine.resume(callback, {'var':{'expr':data.args.var, 'type':data.args.type}, 'val':data.args.val});
 					}

--- a/routes/websocket.js
+++ b/routes/websocket.js
@@ -166,8 +166,8 @@ var onPrivateConnect = function(socket) {
 
 				case 'resume':
 					log.debug('#51846 websocket resume data: ' + JSON.stringify(data))
-					if (data.args && data.args.var && data.args.val) {
-						machine.resume(callback, {'var':data.args.var, 'val':data.args.val});
+					if (data.args && data.args.var && data.args.type && data.args.val) {
+						machine.resume(callback, {'var':{'expr':data.args.var, 'type':data.args.type}, 'val':data.args.val});
 					}
 					machine.resume(callback);
 					break;

--- a/runtime/opensbp/interpolate.js
+++ b/runtime/opensbp/interpolate.js
@@ -75,6 +75,7 @@ log.debug("lineInterpolate: EndPt = " + JSON.stringify(EndPt));
 				    log.error(err);
             throw(err); 
           } 
+          log.debug('#51846 line interpolate: ' + v)
           gcode += (key + v.toFixed(5));
           if(key === "X") { runtime.cmd_posx = v; }
           else if(key === "Y") { runtime.cmd_posy = v; }

--- a/runtime/opensbp/interpolate.js
+++ b/runtime/opensbp/interpolate.js
@@ -74,8 +74,7 @@ log.debug("lineInterpolate: EndPt = " + JSON.stringify(EndPt));
             var err = new Error("Invalid " + key + " argument: " + v );
 				    log.error(err);
             throw(err); 
-          } 
-          log.debug('#51846 line interpolate: ' + v)
+          }
           gcode += (key + v.toFixed(5));
           if(key === "X") { runtime.cmd_posx = v; }
           else if(key === "Y") { runtime.cmd_posy = v; }

--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -1191,8 +1191,8 @@ SBPRuntime.prototype._execute = function(command, callback) {
             // PAUSE is somewhat overloaded.  In a perfect world there would be distinct states for pause and feedhold.
             this.pc += 1;
             var arg = this._eval(command.expr);
-            var var = command.var;
-            log.debug('#51846 var: ' + var)
+            var input_var = command.var;
+            log.debug('#51846 var: ' + input_var)
             log.debug("#51846 pause command: " + JSON.stringify(command));
             if(util.isANumber(arg)) {
                 // If argument is a number set pause with timer and default message.
@@ -1220,8 +1220,8 @@ SBPRuntime.prototype._execute = function(command, callback) {
                     }
                 }
                 var params = {'message' : message || "Paused." };
-                if(var) {
-                    params['input'] = {'name': var.expr, 'type': var.type};
+                if(input_var) {
+                    params['input'] = {'name': input_var.expr, 'type': input_var.type};
                 }
                 this.paused = true;
                 //Set driver in paused state

--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -1188,11 +1188,12 @@ SBPRuntime.prototype._execute = function(command, callback) {
             break;
 
         case "pause":
-            log.debug("50764 pause command");
             // PAUSE is somewhat overloaded.  In a perfect world there would be distinct states for pause and feedhold.
             this.pc += 1;
             var arg = this._eval(command.expr);
             var var_name = command.var;
+            log.debug('#51846 var_name: ' + var_name)
+            log.debug("#51846 pause command: " + JSON.stringify(command));
             if(util.isANumber(arg)) {
                 // If argument is a number set pause with timer and default message.
                 // In simulation, just don't do anything

--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -1192,8 +1192,6 @@ SBPRuntime.prototype._execute = function(command, callback) {
             this.pc += 1;
             var arg = this._eval(command.expr);
             var input_var = command.var;
-            log.debug('#51846 var: ' + input_var)
-            log.debug("#51846 pause command: " + JSON.stringify(command));
             if(util.isANumber(arg)) {
                 // If argument is a number set pause with timer and default message.
                 // In simulation, just don't do anything
@@ -1776,7 +1774,6 @@ SBPRuntime.prototype.emit_move = function(code, pt) {
     var i;
 
     ['X','Y','Z','A','B','C','I','J','K','F'].forEach(function(key){
-        log.debug('#51846 emit move');
         var c = pt[key];
         if(c !== undefined) {
 
@@ -1806,7 +1803,6 @@ SBPRuntime.prototype.emit_move = function(code, pt) {
     var opFunction = function(Pt) {  //Find a better name
         // for(key in tPt) {
         ['X','Y','Z','A','B','C','I','J','K','F'].forEach(function(key){
-            log.debug('#51846 key = ' + key)
             var v = Pt[key];
             if(v !== undefined) {
                 if(isNaN(v)) {
@@ -1931,9 +1927,8 @@ SBPRuntime.prototype.quit = function() {
 
 
 // Resume a program from the paused state
-//   TODO - make some indication that this action was successfil (resume is not always allowed, and sometimes it fails)
+//   TODO - make some indication that this action was successful (resume is not always allowed, and sometimes it fails)
 SBPRuntime.prototype.resume = function(input=false) {
-        log.debug('#51846 osbp resume input: ' + JSON.stringify(input))
         if(this.resumeAllowed) {
             if(this.paused) {
                 if (input) {
@@ -1945,7 +1940,6 @@ SBPRuntime.prototype.resume = function(input=false) {
                             this._executeNext();
                         }
                     }).bind(this);
-                    log.debug('#51846 var: ' + input.var + ' val: ' + input.val,)
 
                     this._assign(input.var, input.val, callback);
                 } else {

--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -1942,7 +1942,7 @@ SBPRuntime.prototype.resume = function(input=false) {
                             this._executeNext();
                         }
                     }).bind(this);
-                    log.debug('#51846 var: ' + input.var + ' val: ' input.val,)
+                    log.debug('#51846 var: ' + input.var + ' val: ' + input.val,)
                     this._assign(input.var, input.val, callback);
                 } else {
                     this.paused = false;

--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -1930,6 +1930,7 @@ SBPRuntime.prototype.quit = function() {
 // Resume a program from the paused state
 //   TODO - make some indication that this action was successfil (resume is not always allowed, and sometimes it fails)
 SBPRuntime.prototype.resume = function(input=false) {
+        log.debug('#51846 osbp resume input: ' + JSON.stringify(input))
         if(this.resumeAllowed) {
             if(this.paused) {
                 if (input) {
@@ -1941,6 +1942,7 @@ SBPRuntime.prototype.resume = function(input=false) {
                             this._executeNext();
                         }
                     }).bind(this);
+                    log.debug('#51846 var: ' + input.var + ' val: ' input.val,)
                     this._assign(input.var, input.val, callback);
                 } else {
                     this.paused = false;

--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -1191,8 +1191,8 @@ SBPRuntime.prototype._execute = function(command, callback) {
             // PAUSE is somewhat overloaded.  In a perfect world there would be distinct states for pause and feedhold.
             this.pc += 1;
             var arg = this._eval(command.expr);
-            var var_name = command.var;
-            log.debug('#51846 var_name: ' + var_name)
+            var var = command.var;
+            log.debug('#51846 var: ' + var)
             log.debug("#51846 pause command: " + JSON.stringify(command));
             if(util.isANumber(arg)) {
                 // If argument is a number set pause with timer and default message.
@@ -1220,8 +1220,8 @@ SBPRuntime.prototype._execute = function(command, callback) {
                     }
                 }
                 var params = {'message' : message || "Paused." };
-                if(var_name) {
-                    params['input'] = var_name;
+                if(var) {
+                    params['input'] = {'name': var.expr, 'type': var.type};
                 }
                 this.paused = true;
                 //Set driver in paused state
@@ -1944,6 +1944,7 @@ SBPRuntime.prototype.resume = function(input=false) {
                         }
                     }).bind(this);
                     log.debug('#51846 var: ' + input.var + ' val: ' + input.val,)
+
                     this._assign(input.var, input.val, callback);
                 } else {
                     this.paused = false;

--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -1776,6 +1776,7 @@ SBPRuntime.prototype.emit_move = function(code, pt) {
     var i;
 
     ['X','Y','Z','A','B','C','I','J','K','F'].forEach(function(key){
+        log.debug('#51846 emit move');
         var c = pt[key];
         if(c !== undefined) {
 
@@ -1805,6 +1806,7 @@ SBPRuntime.prototype.emit_move = function(code, pt) {
     var opFunction = function(Pt) {  //Find a better name
         // for(key in tPt) {
         ['X','Y','Z','A','B','C','I','J','K','F'].forEach(function(key){
+            log.debug('#51846 key = ' + key)
             var v = Pt[key];
             if(v !== undefined) {
                 if(isNaN(v)) {


### PR DESCRIPTION
addresses issue #754.  This restores the functionality of the input on pause to utilize the variable typing that has since been implemented.  

User and persistent variables can be set by following the usual PAUSE message argument with a variable name the variable does not need to be pre-assigned.  On resume from this pause the variable is assigned to the input value and is available for use.

Test Case
PAUSE, 'Set &test to:  ', &test
PAUSE, '&test = ' + &test

&test can then be used for a conditional or as a pause length for a timed pause.  Motion using variables breaks due to issue #758
