### PR TITLE
refs issue #758 parse string to float before calling toFixed()

### DIFF
--- a/machine.js
+++ b/machine.js
@@ -959,7 +959,6 @@ Machine.prototype.quit = function(callback) {
 
 // Resume from the paused state.
 Machine.prototype.resume = function(callback, input=false) {
-	log.debug('#52846 machine resume input: ' + JSON.stringify(input))
 	if (this.driver.pause_hold) {
 		//Release driver pause hold
 		this.driver.pause_hold = false;

--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -1810,7 +1810,7 @@ SBPRuntime.prototype.emit_move = function(code, pt) {
                     log.error(err);
                     throw(err);
                 }
-                gcode += (key + v.toFixed(5));
+                gcode += (key + parseFloat(v).toFixed(5));
             }
         }.bind(this));
         this.emit_gcode(gcode);


### PR DESCRIPTION
Fix for issue #758.

Values input by users are stored as strings leading to type issues when calling float specific functions.

Explicit cast to float before function call corrects this. 