### PR TITLE
refs #765 #767 re-enable send m30 on stat 3 to gcode.

### DIFF
--- a/runtime/gcode/gcode.js
+++ b/runtime/gcode/gcode.js
@@ -171,10 +171,10 @@ GCodeRuntime.prototype._handleStateChange = function(stat) {
             // may change someday in the future on the g2core end, so we may end up revisiting this.
             // OTOH, an extra M30 should not cause a problem.
 			this._changeState('stopped');
-//            if (this._file_or_stream_in_progress) {
-//                this.driver.sendM30();
-//                this._file_or_stream_in_progress = false;
-//            }
+            if (this._file_or_stream_in_progress) {
+            	this.driver.sendM30();
+                this._file_or_stream_in_progress = false;
+            }
 		default:
 			// TODO:  Logging or error handling?
 			break;


### PR DESCRIPTION
It looks like the call to the G2.js driver sendM30 command on a stopped state from G2Core was disabled.

Re-enabling this functionality I am able to run the gcode exemplar in issue #765 back to back multiple time without any hangs.