### PR TITLE
Fix Spindle Off during Program Execution, issue #771

### DIFF
--- a/runtime/opensbp/commands/setting.js
+++ b/runtime/opensbp/commands/setting.js
@@ -10,7 +10,9 @@ var openSBP = require('../opensbp.js');
 exports.SA = function(args, callback) {
 	this.absoluteMode = true;
 	this.emit_gcode("G90");
-	this.emit_gcode("M0"); ////## seems needed for multiple stack-break commands at start 
+	//M0 used to be needed for multiple stack-break commands at start
+	//It does not seem to be needed anymore, leaving comments for documentation
+	//this.emit_gcode("M0");
 	callback();
 };
 
@@ -50,7 +52,9 @@ exports.SK = function(args, callback) {
 exports.SR = function(args, callback) {
 	this.absoluteMode = false;
 	this.emit_gcode("G91");
-	this.emit_gcode("M0"); ////## seems needed for multiple stack-break commands at start 
+	//M0 used to be needed for multiple stack-break commands at start
+	//It does not seem to be needed anymore, leaving comments for documentation
+	//this.emit_gcode("M0");
 	callback();
 };
 


### PR DESCRIPTION
Commented out emit M0 line to fix spindle off during program execution to solve issue [#771](https://github.com/FabMo/FabMo-Engine/issues/771). Discovered issue https://github.com/FabMo/FabMo-Engine/issues/777 in the process.