### PR TITLE
update opensbp zt functionality to zero all 6 axes

### DIFF
--- a/runtime/opensbp/commands/zero.js
+++ b/runtime/opensbp/commands/zero.js
@@ -234,17 +234,24 @@ exports.Z6 = function(args,callback) {
 	}.bind(this));
 };
 
+////## update ZT to cover all axes 2/4/22, will still need to attend to U,V,W
 exports.ZT = function(args, callback) {
 	ztObj = {};
 	ztObj.g55x = 0.0;
 	ztObj.g55y = 0.0;
 	ztObj.g55z = 0.0;
-    this.emit_gcode("G28.3 X0 Y0 Z0");
+	ztObj.g55a = 0.0;
+	ztObj.g55b = 0.0;
+	ztObj.g55c = 0.0;
+    this.emit_gcode("G28.3 X0 Y0 Z0 A0 B0 C0");
 	config.driver.setMany(ztObj, function(err, value) {
 		if(err) { return callback(err); }
 		this.cmd_posx = this.posx = 0.0;
 		this.cmd_posy = this.posy = 0.0;
 		this.cmd_posz = this.posz = 0.0;
+		this.cmd_posa = this.posa = 0.0;
+		this.cmd_posb = this.posb = 0.0;
+		this.cmd_posc = this.posc = 0.0;
 		this.driver.requestStatusReport(function(report) {
 			log.debug("report = " + JSON.stringify(report));
 			callback();


### PR DESCRIPTION
This is a minor update to the ZT function in the sbp runtime that will cause all axes to be zeroed rather than just x,y, and z.

Zeroing in this case means setting the machine-zero offsets to zero as well as removing the G55 working coordinate offset. ZT is thus a complete zeroing. It would be the method to manually set the machine zero after moving all axes to their zero location.

This command can be accomplished partially or for individual axes with the VA command. See the VA command documentation and the documentation for the various Z_ commands in the working draft of the [FabMo Command Ref](https://www.dropbox.com/s/dkdsnwqjj9nq04m/SBG00353%20FabMo%20OpenSBP%20Command%20Reference.docx?dl=0). This documentation describes the operation of FabMo's coordinate systems.

The ZT command may need a further update after we implement U, V, and W axes.

This PR finishes issue #781. The only remaining aspect of 781 is a question that applies to several commands that adjust configuration values and thus trigger an update of the file and a re-sync with G2 that may be creating some race conditions.