### PR TITLE
enabling display of C axis and related functions

### DIFF
--- a/dashboard/build/index.html
+++ b/dashboard/build/index.html
@@ -102,10 +102,10 @@
               <div class="zaxis machine-pos" ><label>Z : &nbsp;<span class="posz">Z.ZZZ</span></label></div>
               <div class="aaxis machine-pos" ><label>A : <span class="posa">A.AAA</span></label></div>
               <div class="baxis machine-pos" ><label>B : <span class="posb">B.BBB</span></label></div>
-              <!--<div class="caxis machine-pos" style="display:none" ><label>C : <span class="posc">C.CCC</span></label></div> -->
-              <!-- ////## could not figure how C display controlled -->
+              <div class="caxis machine-pos" ><label>C : <span class="posc">C.CCC</span></label></div>
               
               <!-- <div class="fabmo-status machine-pos" ><label><span class="state"></label></div> -->
+
             </strong></div>
             <div >
               <div class="inoutLabel ">In:</div>
@@ -203,7 +203,7 @@
               <div class="zaxis machine-pos-large" ><label>Z : <span class="posz">Z.ZZZ</span></label></div>
               <div class="aaxis machine-pos-large" ><label>A : <span class="posa">A.AAA</span></label></div>
               <div class="baxis machine-pos-large" ><label>B : <span class="posb">B.BBB</span></label></div>
-            <!--  <div class="caxis machine-pos-large" ><label>C : <span class="posc">C.CCC</span></label></div> -->
+              <div class="caxis machine-pos-large" ><label>C : <span class="posc">C.CCC</span></label></div>
             </div>
         <!-- ********** Tool Position Widget ********** -->
 
@@ -291,7 +291,6 @@
                 <span class="rotunits">o&nbsp;</span>
                 <div class="zero-button zero-b">zero</div>
             </div>
-<!--
             <div class="axis caxis">
                 <label class="noselect">
                 C
@@ -300,7 +299,6 @@
                 <span class="rotunits">o&nbsp;</span>
                 <div class="zero-button zero-c">zero</div>
             </div>
--->
           </div>
         </div>
         <div class="manual-right-side-container">

--- a/dashboard/static/js/libs/fabmoui.js
+++ b/dashboard/static/js/libs/fabmoui.js
@@ -231,7 +231,8 @@ FabMoUI.prototype.updateStatusContent = function(status){
 		that.updateText($(that.units_selector), unit)
 	}
 
-	['x','y','z','a','b'].forEach(function(axis) {
+    ////## key DRO display stuff
+	['x','y','z','a','b','c'].forEach(function(axis) {
 		var pos = 'pos' + axis;
 		if(pos in status) {
 			if(axis === "b") {

--- a/dashboard/static/js/main.js
+++ b/dashboard/static/js/main.js
@@ -287,9 +287,7 @@ require("../css/toastr.min.css");
                                                 modalOptions.cancel = cancelFunction
                                                 break;
                                             default:
-                                                modalOptions.cancel = function() {
-                                                                        modalIsShown = false;
-                                                                    }
+                                                modalOptions.cancel = false
                                         }
                                     }
                                     if (status.info.custom['detail']) {
@@ -319,9 +317,14 @@ require("../css/toastr.min.css");
                                 title: 'An Error Occurred!',
                                 message: status.info.error,
                                 detail: detailHTML,
-                                cancelText: 'Close',
-                                cancel: function() {
-                                    modalIsShown = false;
+                                cancelText: status.state === 'dead' ? undefined : 'Quit',
+                                cancel: status.state === 'dead' ? undefined : function() {
+                                    dashboard.engine.quit(function(err, result) {
+                                                            if (err) {
+                                                              console.log("ERRROR: " + err);
+                                                            }
+                                                        }
+                                                    );
                                 }
                             });
                             modalIsShown = true;
@@ -667,6 +670,7 @@ require("../css/toastr.min.css");
             $('.posz').val($('.posz').val());
             $('.posa').val($('.posa').val());
             $('.posb').val($('.posb').val());
+            $('.posc').val($('.posc').val());
             $('#keypad').show();
             $('.go-to-container').hide();
             if($(event.target).hasClass('fixed-step-value')){
@@ -696,6 +700,7 @@ require("../css/toastr.min.css");
         var axi = $(this).parent('div').find('input').attr('id');
         var obj = {};
         obj[axi] = 0;
+console.log('zero- ',axi,obj,obj[axi]);        
         dashboard.engine.set(obj)
     });
 

--- a/machine.js
+++ b/machine.js
@@ -201,10 +201,9 @@ function Machine(control_path, callback) {
 	// If any of the axes in G2s configuration become enabled or disabled, we want to show or hide
 	// them accordingly.  These change events happen even during the initial configuration load, so
 	// right from the beginning, we will be displaying the correct axes.
-	////## TODO - extra axes
 	// TODO - I think it's good to used named callbacks, to make the code more self-documenting
     config.driver.on('change', function(update) {
-    	['x','y','z','a','b'].forEach(function(axis) {
+    	['x','y','z','a','b','c'].forEach(function(axis) {
     		var mode = axis + 'am';
     		var pos = 'pos' + axis;
     		if(mode in update) {
@@ -917,9 +916,6 @@ Machine.prototype.setState = function(source, newstate, stateinfo) {
 				break;
 			case 'dead':
 				log.error('G2 is dead!');
-				break;
-			case 'stopped':
-				log.debug('Entering stopped state for error report');
 				break;
 			default:
 				break;

--- a/runtime/manual/driver.js
+++ b/runtime/manual/driver.js
@@ -318,6 +318,9 @@ ManualDriver.prototype.set = function(pos) {
 					case "B": 
 						toSet.g55b = Number(((MPO.b* 1) - pos[key]).toFixed(5));
 						break;
+                    case "C": 
+						toSet.g55c = Number(((MPO.c* 1) - pos[key]).toFixed(5));
+						break;
 					default:
 						log.error("don't understand axis");
 				}

--- a/runtime/opensbp/commands/probe.js
+++ b/runtime/opensbp/commands/probe.js
@@ -97,7 +97,7 @@ exports.PB = function(args) {
 
 
 exports.PC = function(args) {
-	this.cmd_pos
+	this.cmd_posc = undefined
 	probe(this, {
 		inp : args[2],
 		feed : args[1],


### PR DESCRIPTION
Most of the elements for display and manipulation of the C axis in parallel to the other rotary axes, A & B, was already stubbed in. Some of it present, some of it commented out.

And, a number of little odds and ends had to be updated for all 6 axes.

Note that there is no manual keypad display of additional buttons for the C axis. Just have not decided how that should look.
Note also, that it might be good to update the numbered ordering of opensbp system variables incorporating additional axes, inputs/outputs, and other changes due to FabMo ... doing this now before people really start using FabMo.