### PR TITLE
allows sk (manual keypad) to run and exit within file; esp. case of a…

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "command": "npm run dev",
+            "name": "Run npm dev",
+            "request": "launch",
+            "type": "node-terminal"
+        },
+        {
+            "name": "Launch Program",
+            "program": "${workspaceFolder}/server.js",
+            "request": "launch",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "type": "pwa-node"
+        },
+        {
+            "type": "pwa-chrome",
+            "request": "launch",
+            "name": "Open index.html",
+            "file": "/fabmo/dashboard/apps/configuration.fma/index.html"
+        }
+    ]
+}

--- a/runtime/manual/driver.js
+++ b/runtime/manual/driver.js
@@ -42,6 +42,7 @@ function ManualDriver(drv, st, mode) {
 	this.fixedQueue = [];
 	this.entered = false;
 	this.exited = false;
+    this.fromFile = false;
 
 	// True while the tool is known to be in motion
 	this.moving = false;
@@ -91,14 +92,14 @@ ManualDriver.prototype.enter = function() {
 			// "dummy" move to prod the machine into issuing a status report
 			this.stream.write('M100.1 ({zl:0})\nM0\nG91\n G0 X0 Y0 Z0\n');	
 			this.driver.prime();		
-			break;
+		    break;
 		case 'raw':
 			this.stream.write('M100.1 ({zl:0})\nM0\n');
 			this.driver.prime();		
-		break;
+		    break;
 		default:
 			log.warn('Unknown manual drive mode on enter: ' + this.mode);
-		break;
+		    break;
 	}
 	this.entered = true;
 	this.deferred = Q.defer();
@@ -116,35 +117,28 @@ ManualDriver.prototype.exit = function() {
 		this.stopMotion();
 	} else {
 		log.debug('Executing immediate exit')
-		this.driver.manual_hold = false;
+		this.driver.manual_hold = false;    ////## PROBLEM area for exiting SK when used in file
 		switch(this.mode) {
 			case 'normal':
-				config.driver.restoreSome(['xjm','yjm','zjm', 'zl'], function() {
-				    this._done();
-		        }.bind(this));	
-		        this.stream.write('G61\n'); ////## making sure not left in exact stop mode
-				this.stream.write('M30\n');
-				////## added to maintain line number priming in all scenarios ...
-				this.driver.queueFlush(function() {
-					this.driver.resume();		
-				}.bind(this));
+                // Potential additional Manual Keypad post-pend commands 
 		        break;
 			case 'raw':
-				config.driver.restoreSome(['xjm','yjm','zjm', 'zl'], function() {
-				    this._done();
-		        }.bind(this));
-		        this.stream.write('G61\n'); ////## making sure not left in exact stop mode
-				this.stream.write('M30\n');
-				////## added to maintain line number priming in all scenarios ...
-				this.driver.queueFlush(function() {
-					this.driver.resume();		
-				}.bind(this));
+                // Potential additional Manual 'raw' post-pend commands 
 				break;
 			default:
 				log.warn('Unknown manual drive mode on exit: ' + this.mode);
 				break;
 		}
-		this.driver.removeListener('status', this.status_handler);
+        config.driver.restoreSome(['xjm','yjm','zjm', 'zl'], function() {
+            this._done();
+        }.bind(this));	
+        this.stream.write('G61\n');     // don't leave in exact stop mode from nudge
+        if(this.fromFile) {
+            this.stream.write('M0\n');  // avoid triggering stat:4 when in file
+        } else {
+            this.stream.write('M30\n');    
+        }
+        this.driver.removeListener('status', this.status_handler);
 		this.exited = true;
 		this._done();
 	}
@@ -274,7 +268,6 @@ ManualDriver.prototype.runGCode = function(code) {
 //   pos - Position vector as an object, eg: {"X":10, "Y":5}
 ManualDriver.prototype.goto = function(pos) {
 	var move = "G90\nG0 ";
-
 	for (var key in pos) {
 		if (pos.hasOwnProperty(key)) {
 			move += key + pos[key] + " ";
@@ -285,7 +278,7 @@ ManualDriver.prototype.goto = function(pos) {
 	this.stream.write(move);
 }
 
-// Set the machine position to the specified vector ////## meaning "location" here not move vector?
+// Set the machine position to the specified "location"
 // TODO: Is it possible that timing could produce an inaccurate position update here???
 // TODO: ** pretty scary to reset location after zeroing and not do it by offset???
 //   pos - New position vector as an object,  eg: {"X":10, "Y":5}
@@ -340,11 +333,12 @@ ManualDriver.prototype.set = function(pos) {
 
 }
 
-// Internal function for handling nudges.
+// Internal function for handling nudges. (This function called "Fixed" moves in Sb3; there, nudges were 
+// moves inserted at a Stop in the middle of a file; G2 would allow implementation of this behavior.)
 // Nudges are little fixed incremental moves that are usually initiated by a short tap on one of the
 // direction keys on a pendant display, or by pressing the direction keys in a specified "fixed" mode
-// If the machine is currently in the middle of a nudge or is moving in a long move, the nudge is queued,
 // and executed at the end of the current move.  This is the function that dequeues and executes them.
+// Nudges are made fixed and individual by G61.1.
 // TODO: Like start above, nudges should be arbritrary vectors rather than axis, second_axis
 // Returns the number of nudges
 ManualDriver.prototype._handleNudges = function() {
@@ -358,8 +352,7 @@ ManualDriver.prototype._handleNudges = function() {
 			var axis = move.axis.toUpperCase();
 
 			if('XYZABCUVW'.indexOf(axis) >= 0) {
-				log.debug("===> setting to exact distance")
-				var moves = ['G91 G61.1'];  ////## setting exact distance for fixed-moves/nudges so g2 does not build longer vector
+				var moves = ['G91 G61.1'];  // set to exact fixed distance
 				if(move.second_axis) {
 					var second_axis = move.second_axis.toUpperCase();
 					if(move.speed) {
@@ -374,9 +367,6 @@ ManualDriver.prototype._handleNudges = function() {
 						moves.push('G0 ' + axis + move.distance.toFixed(5) + ' F' + move.speed.toFixed(3))
 					}
 				}
-				
-				// You can't put an M0 or a G4 in here to break up the nudges.
-				// Don't do it. Doooon't do it.
 				moves.forEach(function(move) {
 					this.stream.write(move + '\n');
 				}.bind(this));
@@ -389,15 +379,15 @@ ManualDriver.prototype._handleNudges = function() {
 	return count;
 }
 
-// Issue a nudge (small fixed move)  If the machine is already moving, queue up the nudge.
+// Issue a nudge (small fixed move).
 // Don't queue more than FIXED_MOVES_QUEUE_SIZE, though, to keep the machines behavior from running away.
+// (TODO: Might consider making this a typematic sort of thing where after a time you get a machine gun effect.)
 // ie: You shoudln't be allowed to queue 50 nudges during a long slow move, and see them execute at the end.
 //              axis - The first axis to move (eg "X")
 //             speed - The speed in current units
 //          distance - The length of the nudge
 //       second_axis - The second axis to move
 //   second_distance - The second axis speed
-
 ManualDriver.prototype.nudge = function(axis, speed, distance, second_axis, second_distance) {
     if(this.fixedQueue.length >= FIXED_MOVES_QUEUE_SIZE) {
 	log.warn('fixedMove(): Move queue is already full!');
@@ -408,7 +398,6 @@ ManualDriver.prototype.nudge = function(axis, speed, distance, second_axis, seco
 	} else {
 		this.fixedQueue.push({axis: axis, speed: speed, distance: distance});
 	}
-
     if(this.moving) {
 		log.warn("fixedMove(): Queueing move, due to already moving.");
 	} else {

--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -172,6 +172,7 @@ SBPRuntime.prototype.executeCode = function(s, callback) {
                     }
                     switch(s.cmd) {
                         case 'exit':
+                            this.helper.fromFile = true;   // flag that this is SK invoked in file; will surpress M30/stat:4
                             this.helper.exit();
                             break;
         


### PR DESCRIPTION
… macro call following

*OOops ... sorry Rob. Should have gitignored my vscode.launch file ... just noticed after I had written this. 

Before this fix, this would work:
---------------------------------------
mx,1
sk "Now we will do something interesting!"
'C2
mx,0
---------------------------------------
But if the comment was removed, then when the keypad was closed the file would just end.
This is a result of the Keypad being it's own runtime and exiting with an M30, that in many cases (e.g. macros calls and PAUSE, etc) triggers a stat:4 that forces an exit and close of the file rather than continuing.

The fix involved flagging the Opensbp file-running case and for that case not emitting the M30 when the Keypad is closed. 

The premature stat:4 completes an open promise and this is the cause of the shutdown. More generally, I'm thinking that the use of the keypad should probably be embedded in it's own promise and that handle this, but the whole manual run-time is a bit convoluted at this point, so I did not go there.