### PR TITLE
793 780 error bugs

### DIFF
--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -976,16 +976,16 @@ SBPRuntime.prototype._end = function(error) {
             if(this.machine.status.job) {
                 this.machine.status.job.finish(function(err, job) {
                     this.machine.status.job=null;
-                    cleanup(error);
+                    cleanup(error_msg);
                     this.machine.setState(this, 'idle');
                 }.bind(this));
             } else {
-                cleanup(error);
+                cleanup(error_msg);
                 this.machine.setState(this, 'idle');
             }
         }.bind(this));
     } else {
-        cleanup(error);
+        cleanup(error_msg);
     }
 };
 

--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -326,7 +326,7 @@ SBPRuntime.prototype.runStream = function(text_stream) {
 
             // Stream is fully processed
             st.on('end', function() {
-                log.debug('#780 runstream program:  ' + JSON.stringify(this.program))
+
                 try {
                     log.tock('Parse file')
 

--- a/runtime/opensbp/parser.js
+++ b/runtime/opensbp/parser.js
@@ -69,7 +69,10 @@ fastParse = function(statement) {
 // Tries to fast parse first, falls back on the more thorough pegjs parser
 parseLine = function(line) {
     line = line.replace(/\r/g,'');
-
+    //Check for metadata
+    if (line.includes('!FABMO!')) {
+        return {"type":"metadata"};
+    }
     // Extract end-of-line comments
     parts = line.split("'");
     statement = parts[0]
@@ -96,12 +99,7 @@ parseLine = function(line) {
     
     // Deal with full-line comments
     if(Array.isArray(obj) || obj === null) {
-        //TODO: Parser should ID header Metadata and comment distinctly
-        if (comment.indexOf('!FABMO!') !== -1) {
-            obj = {"type":"metadata"};
-        } else {
             obj = {"type":"comment", "comment":comment};
-        }
     } else {
         if(comment != '') {obj.comment = comment}
     }

--- a/runtime/opensbp/parser.js
+++ b/runtime/opensbp/parser.js
@@ -96,7 +96,12 @@ parseLine = function(line) {
     
     // Deal with full-line comments
     if(Array.isArray(obj) || obj === null) {
-        obj = {"type":"comment", "comment":comment};
+        //TODO: Parser should ID header Metadata and comment distinctly
+        if (comment.indexOf('!FABMO!') !== -1) {
+            obj = {"type":"metadata"};
+        } else {
+            obj = {"type":"comment", "comment":comment};
+        }
     } else {
         if(comment != '') {obj.comment = comment}
     }
@@ -163,7 +168,11 @@ Parser.prototype._transform = function(chunk, enc, cb) {
       for(var i=0; i<str.length; i++) {
             if(str[i] === '\n') {
                 var substr = str.substring(start, i)
-                this.push(parseLine(substr));
+                let parsedline = parseLine(substr)
+                //Skip entries that are metadata (Used to prune header metadata on macros)
+                if (parsedline.type != 'metadata') {
+                    this.push(parsedline);
+                }
                 start = i+1;
             }
         }


### PR DESCRIPTION
Corrects Issue #793 and Issue #780  
Correctly uses error_msg instead of error for error message report during cleanup.
Adjusts Line Number reports to be more consistently supplied at the time of error.
Prunes Macro Metadata as part of parsing files for run.  This prevents the metadata from being included in the program stack at runtime.

One commit to address each of these issues with all cosmetic and debug changes squashed into those commits by rebase.