### PR TITLE
Input switch stop

### DIFF
--- a/g2.js
+++ b/g2.js
@@ -552,13 +552,14 @@ G2.prototype.handleStatusReport = function(response) {
 				switch(response.sr.stat) {
 					case STAT_HOLDING:
 						this.pause_flag = true;
-						this.status.inFeedHold = false;        // for sensing input-generated-hold                
+						this.status.inFeedHold = true;        // for sensing input-generated-hold                
 						if(this.context) {
 							this.context.pause()
 						}
 						break;
 					default:
 						this.pause_flag = false;
+						this.status.inFeedHold = false;                        
 						if(this.context) {
 							this.context.resume();
 						}

--- a/g2.js
+++ b/g2.js
@@ -543,6 +543,7 @@ G2.prototype.handleStatusReport = function(response) {
 						this.lines_to_send = 4
 						this.quit_pending = false;
 						this.pause_flag = false;
+						this.status.inFeedHold = false;                        
 						break;
 				}
 			} else {
@@ -551,6 +552,7 @@ G2.prototype.handleStatusReport = function(response) {
 				switch(response.sr.stat) {
 					case STAT_HOLDING:
 						this.pause_flag = true;
+						this.status.inFeedHold = false;        // for sensing input-generated-hold                
 						if(this.context) {
 							this.context.pause()
 						}

--- a/machine.js
+++ b/machine.js
@@ -896,7 +896,6 @@ Machine.prototype.setState = function(source, newstate, stateinfo) {
                 if(this.status.state != newstate) {
                     //set driver in paused state
                     this.driver.pause_hold = true;
-                    this.status.inFeedHold = true;
                     // Save the position to the instance configuration.  See note above.
                     this.driver.get('mpo', function(err, mpo) {
 					    if(config.instance) {

--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -750,7 +750,7 @@ SBPRuntime.prototype._run = function() {
                         if(this.pendingFeedhold) {
                             this.pendingFeedhold = false;
                             this.driver.feedHold();
-                            this.machine.status.inFeedHold = true;
+                            this.machine.status.inFeedHold = false;
                         }
                     }
                 }


### PR DESCRIPTION
Hey Kyle, have a look at this. A slightly different approach to getting the feed-hold started.

I believe we have a bigger issue with the stop button in that it allows a RESUME or a restart if it is held down ... which we probably don't want. Worth taking a look at how the "INTERUPT" action for an input works ... maybe better?

But I think we can go with the way the STOP action works for the moment.