### PR TITLE
811 imbedded macro bug

### DIFF
--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -366,21 +366,36 @@ SBPRuntime.prototype.runStream = function(text_stream) {
                     // Start running the actual code, now that everything is prepped
                     return this._run();
                 } catch(e) {
-                    log.error(e)
-                    this._end(e.message);
+                    if(this.isInSubProgram()) {
+                        log.error(e);
+                        this._abort(e);
+                    } else {
+                        log.error(e)
+                        this._end(e.message);
+                    }
                 }
 
             }.bind(this));
             return undefined;
 
         } catch(e) {
-            log.error(e)
-            this._end(e.message);
+            if(this.isInSubProgram()) {
+                log.error(e);
+                this._abort(e);
+            } else {
+                log.error(e)
+                this._end(e.message);
+            }
         }
         return st;
     } catch(e) {
-        log.error(e);
-        this._end(e.message);
+        if(this.isInSubProgram()) {
+            log.error(e);
+            this._abort(e);
+        } else {
+            log.error(e)
+            this._end(e.message);
+        }
     }
 }
 

--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -300,8 +300,13 @@ SBPRuntime.prototype.runString = function(s) {
 
     } catch(e) {
         // A failure at any stage (except parsing) will land us here
-        log.error(e);
-        this._end(e.message);
+        if(this.isInSubProgram()) {
+            log.error(e);
+            this._abort(e);
+        } else {
+            log.error(e)
+            this._end(e.message);
+        }
     }
 };
 


### PR DESCRIPTION
Implemented a check for if we're in a subprogram when an error is encountered during parse/pre-run checks  and appropriately abort or end based on result.

This solves issue #811 