### PR TITLE
Gcode runtime, commented out sendM30 if stat 3 is received

### DIFF
--- a/runtime/gcode/gcode.js
+++ b/runtime/gcode/gcode.js
@@ -176,9 +176,15 @@ GCodeRuntime.prototype._handleStateChange = function(stat) {
             // There may have been an M30 in the file but the g2core will have ignored it, this
             // may change someday in the future on the g2core end, so we may end up revisiting this.
             // OTOH, an extra M30 should not cause a problem.
+			
+			// As of 04/04/2022 the extra m30 seems to be a problem.
+			// Before commenting out this.driver.sendM30, files would end whenever a stat 3 was received
+			// which is not always at the end of the file. If the operator forgets to add an m30
+			// to the end of their file then FabMo will stall requiring ESC key to be hit.
+			// I am writing that up as a seperate enhancement issue 
 			this._changeState('stopped');
             if (this._file_or_stream_in_progress) {
-            	this.driver.sendM30();
+            	//this.driver.sendM30();
                 this._file_or_stream_in_progress = false;
             }
 		default:

--- a/runtime/gcode/gcode.js
+++ b/runtime/gcode/gcode.js
@@ -176,15 +176,15 @@ GCodeRuntime.prototype._handleStateChange = function(stat) {
             // There may have been an M30 in the file but the g2core will have ignored it, this
             // may change someday in the future on the g2core end, so we may end up revisiting this.
             // OTOH, an extra M30 should not cause a problem.
-			
+
 			// As of 04/04/2022 the extra m30 seems to be a problem.
 			// Before commenting out this.driver.sendM30, files would end whenever a stat 3 was received
 			// which is not always at the end of the file. If the operator forgets to add an m30
-			// to the end of their file then FabMo will stall requiring ESC key to be hit.
-			// I am writing that up as a seperate enhancement issue 
+			// to the end of their file then FabMo will stall and show an empty footer, requiring ESC key to be hit.
+			// I am writing that up as a seperate enhancement issue
 			this._changeState('stopped');
             if (this._file_or_stream_in_progress) {
-            	//this.driver.sendM30();
+			    //this.driver.sendM30();
                 this._file_or_stream_in_progress = false;
             }
 		default:


### PR DESCRIPTION
This change addresses issue https://github.com/FabMo/FabMo-Engine/issues/844. Commented out 1 line in gcode runtime. Whenever g2 reported a stat 3, the program would end early by sending an m30. I could not find a good way to replicate this. It seemed very random. Sometimes it would happen 3 times in a row, sometimes it would not happen for 10 consecutive runs. Either way, my understanding is that stat:3 means that the queue is out of gcode but can be fed more. Sending an m30 just because of a stat 3 does not make any sense. The major setback of this change is the operator must put an m30 at the end of their file. I am adding an issue requesting that we enhance this however we see fit.  