### PR TITLE
Check manual keypad fixed distance for null

### DIFF
--- a/runtime/manual/index.js
+++ b/runtime/manual/index.js
@@ -154,6 +154,9 @@ ManualRuntime.prototype.executeCode = function(code) {
 					break;
 
 				case 'fixed':
+					if(code.dist == null){
+						break;
+					}
 					if(!this.helper) {
 						this.enter();
 					}


### PR DESCRIPTION
Keypad fixed distance was never being checked for "null" inputs. If the input was not properly formatted (a word, ..01, !, ~) then code.dist was being assigned null. This caused fabmo to lock up. 