### PR TITLE
Bulletproofing against eth0 disappearing

### DIFF
--- a/network/linux/raspberry-pi/index.js
+++ b/network/linux/raspberry-pi/index.js
@@ -159,7 +159,7 @@ RaspberryPiNetworkManager.prototype.checkWifiHealth = function() {
   // the current IP address
   if((!this.network_history) ||
         // ^^ we had never done this before
-     (!this.network_history[wiredInt] && interfaces[wiredInt][0].address) ||
+     (!this.network_history[wiredInt] && interfaces[wiredInt]?.[0]?.address) ||
         //^^  eth0 just showed up            ^^^^^^
      (this.network_history[wiredInt] &&  !interfaces[wiredInt]) ||
         //^^ looks like eth0 just disappeared ^^^^^^^


### PR DESCRIPTION
In cases where eth0 was previously connected to the device and it then goes away, we'd be looking at properties of objects that just don't exist anymore.

Here we use javascript optional chaining to short-circuit the failure cases.

At least locally this fixes #875