### PR TITLE
Comment out the /profile route, as it depends on other commented out code.

### DIFF
--- a/routes/config.js
+++ b/routes/config.js
@@ -232,7 +232,7 @@ module.exports = function(server) {
   server.post('/config', post_config);
   server.get('/version', get_version);
   server.get('/info', get_info);
-  server.get('/profile', profile);
+  // server.get('/profile', profile); // TODO - This is paired with "var profile" above and should be removed along with it.
   server.get('/profiles', getProfiles);
 
 };


### PR DESCRIPTION
I don't know the codebase well enough to know if this code should all just be deleted or re-added, although I sort of suspect it should all just get deleted.
Leaving it hanging around commented out feels not ideal.



From my logs:
May 14 20:46:13 fabmo FBMO[22297]: UNCAUGHT EXCEPTION
May 14 20:46:13 fabmo FBMO[22297]: TypeError: Cannot read properties of undefined (reading 'getData')
May 14 20:46:13 fabmo FBMO[22297]:     at get_config (/fabmo/routes/config.js:51:35)
May 14 20:46:13 fabmo FBMO[22297]:     at nextTick (/fabmo/node_modules/restify/lib/chain.js:167:13)
May 14 20:46:13 fabmo FBMO[22297]:     at processTicksAndRejections (node:internal/process/task_queues:78:11)