### PR TITLE
DEFER: Improve usb thumb files

### DIFF
--- a/bin/collect_and_export_data_to_usb_drive
+++ b/bin/collect_and_export_data_to_usb_drive
@@ -39,6 +39,9 @@ $work_index{'shopbotsupport.txt'} = \&capture_shopbotsupport_info;
 
 ## Work functions ##########################################
 
+# this function gets the pi's network interface info in formatted form, and then dumps it into 2 files
+#   the file that triggered the function to be called  ($target_file) which will be overwritten
+#   a file named fabmo.html in the same directory which will also be overwritten
 sub capture_network_info() {
 
 	# parameter processing
@@ -69,8 +72,8 @@ sub collect_ifconfig () {
 	my $html_file_contents =
 		"<html> <body> <p> <br/> " .
 		"<h1> Click on this link in your browser to access FabMo: " .
-		"<a href=\"http://$eth0\"> FabMo </a> </h1>" .
-		"or copy and paste this to your browser address bar: <b> http://$eth0 </b> </p>" .
+		"<a href=\"http://$eth0\"> FabMo </a> </h1> \n\n" .
+		"or copy and paste this to your browser address bar: <b> http://$eth0 </b> </p>\n\n" .
 		"<p> Once you have FabMo open on your tool, you will probably want to create a " .
 		"bookmark in your browser to make returning to FabMo easier.  </p> </body> </html>";
 

--- a/bin/collect_and_export_data_to_usb_drive
+++ b/bin/collect_and_export_data_to_usb_drive
@@ -47,7 +47,7 @@ sub capture_network_info() {
 	my ($message,  $html_file) = collect_ifconfig();
 
 	# file creation
-	system("echo \'$message\' > \'$target_file\'");
+	system("echo \"$message\" > \"$target_file\"");
 	system("echo \'$html_file\' > \'$path_to_file/fabmo.html\'");
 }
 

--- a/bin/collect_and_export_data_to_usb_drive
+++ b/bin/collect_and_export_data_to_usb_drive
@@ -40,34 +40,40 @@ $work_index{'shopbotsupport.txt'} = \&capture_shopbotsupport_info;
 ## Work functions ##########################################
 
 sub capture_network_info() {
+
+	# parameter processing
 	my $target_file = shift(@_); #grab the parameter:w
 	my $path_to_file= shift(@_); #grab the path parameter
 	my ($message,  $html_file) = collect_ifconfig();
-	system("echo \"$message\" > \"$target_file\"");
-	logmsg("html_file 2: == $html_file");
+
+	# file creation
+	system("echo \'$message\' > \'$target_file\'");
 	system("echo \'$html_file\' > \'$path_to_file/fabmo.html\'");
-	logmsg("$message");
-	logmsg("$html_file");
 }
 
 sub collect_ifconfig () {
+
+	# gather info from system
 	my $eth0 = `/sbin/ifconfig eth0 | /bin/grep "inet " | /bin/sed "s/inet/ip address/" | /usr/bin/cut -c 9-`;
 	$eth0 =~ s/[^\d]*(\d+\.\d+\.\d+\.\d+).*/$1/;
-	chomp($eth0);
-        my $network =  `/sbin/ifconfig`;
+	chomp($eth0); # $eth0 should now be a simple IP Address with no other text 
+        my $network =  `/sbin/ifconfig`;  # this will be the full network config dump
+
+	# Build messages
 	my $message ="\\n\\n\\nYour ShopBot Tool's IP Address is: $eth0\\n" .
 		     "\\n" .
 	             "\\n\\n================ Full Network ================\\n"  .
 	             "      Useful for tech support and debugging\\n\\n"  .
                      $network;
+
 	my $html_file_contents =
-        "<html> <body> <p> <br/> " .
-        "<h1> Click on this link in your browser to access FabMo: " .
-        "<a href=\"http://$eth0\"> FabMo </a> </h1>" .
-	"or copy and paste this to your browser address bar: <b> http://$eth0 </b> </p>" .
-        "<p> Once you have FabMo open on your tool, you will probably want to create a bookmark " .
-        "in your browser to make returning to FabMo easier.  </p> </body> </html>";
-	logmsg("html file == $html_file_contents");
+		"<html> <body> <p> <br/> " .
+		"<h1> Click on this link in your browser to access FabMo: " .
+		"<a href=\"http://$eth0\"> FabMo </a> </h1>" .
+		"or copy and paste this to your browser address bar: <b> http://$eth0 </b> </p>" .
+		"<p> Once you have FabMo open on your tool, you will probably want to create a " .
+		"bookmark in your browser to make returning to FabMo easier.  </p> </body> </html>";
+
 	return($message, $html_file_contents);
 }
 

--- a/bin/collect_and_export_data_to_usb_drive
+++ b/bin/collect_and_export_data_to_usb_drive
@@ -41,22 +41,34 @@ $work_index{'shopbotsupport.txt'} = \&capture_shopbotsupport_info;
 
 sub capture_network_info() {
 	my $target_file = shift(@_); #grab the parameter:w
-	my $message = collect_ifconfig();
+	my $path_to_file= shift(@_); #grab the path parameter
+	my ($message,  $html_file) = collect_ifconfig();
 	system("echo \"$message\" > \"$target_file\"");
+	logmsg("html_file 2: == $html_file");
+	system("echo \'$html_file\' > \'$path_to_file/fabmo.html\'");
 	logmsg("$message");
+	logmsg("$html_file");
 }
 
 sub collect_ifconfig () {
 	my $eth0 = `/sbin/ifconfig eth0 | /bin/grep "inet " | /bin/sed "s/inet/ip address/" | /usr/bin/cut -c 9-`;
+	$eth0 =~ s/[^\d]*(\d+\.\d+\.\d+\.\d+).*/$1/;
+	chomp($eth0);
         my $network =  `/sbin/ifconfig`;
-	my $message ="\\nYour ShopBot Tool's networking information is listed below\\n" .
-                     '\\n==================== eth0 ====================\\n\\n' .
-                     '            vvvvvvvvvvv\\n' .
-                     $eth0 .
-                     '            ^^^^^^^^^^^\\n' .
-	             '\\n\\n================ Full Network ================\\n'  .
+	my $message ="\\n\\n\\nYour ShopBot Tool's IP Address is: $eth0\\n" .
+		     "\\n" .
+	             "\\n\\n================ Full Network ================\\n"  .
+	             "      Useful for tech support and debugging\\n\\n"  .
                      $network;
-	return($message);
+	my $html_file_contents =
+        "<html> <body> <p> <br/> " .
+        "<h1> Click on this link in your browser to access FabMo: " .
+        "<a href=\"http://$eth0\"> FabMo </a> </h1>" .
+	"or copy and paste this to your browser address bar: <b> http://$eth0 </b> </p>" .
+        "<p> Once you have FabMo open on your tool, you will probably want to create a bookmark " .
+        "in your browser to make returning to FabMo easier.  </p> </body> </html>";
+	logmsg("html file == $html_file_contents");
+	return($message, $html_file_contents);
 }
 
 


### PR DESCRIPTION
This fix causes the presence of a "network.txt" on an inserted usb to trigger *both* the overwrite of "network.txt" with the network configi info  *and* the creation/overwrite of a local webpage named "fabmo.html". The webpage is emitted such that it has a direct link to fabmo on it. so that the user can double click on the "fabmo.html" and then click on the link and then go to their fabmo installation.