### PR TITLE
Authorization is now required after resuming from feedhold

### DIFF
--- a/machine.js
+++ b/machine.js
@@ -1026,23 +1026,20 @@ Machine.prototype.resume = function(callback, input=false) {
 		//Release driver pause hold
 		this.driver.pause_hold = false;
 	}
-	if (this.current_runtime && this.status.inFeedHold){
-		this._resume(input);
+	
+	//clear any timed pause
+	if (this.pauseTimer) {
+		clearTimeout(this.pauseTimer);
+		this.pauseTimer = false;
+	}
+	this.arm({
+		'type' : 'resume',
+		'input' : input
+	}, config.machine.get('auth_timeout'));
+	if (callback) {
+		callback(null, 'resumed');
 	} else {
-		//clear any timed pause
-		if (this.pauseTimer) {
-			clearTimeout(this.pauseTimer);
-			this.pauseTimer = false;
-		}
-		this.arm({
-			'type' : 'resume',
-			'input' : input
-		}, config.machine.get('auth_timeout'));
-		if (callback) {
-	    	callback(null, 'resumed');
-	    } else {
-	    	log.debug('Undefined callback passed to resume');
-	    }
+		log.debug('Undefined callback passed to resume');
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/FabMo/FabMo-Engine/issues/921. Run this file (or any file) and make sure that authorization is enabled and configured properly. This means having authorization enabled and assigned an input on the configuration/machine/safety page, then on the configurations/inputs page that input should be enabled and set to "cycle start-restart":
SO, 1,1
MZ, 0
MX, 10
MX, 0
MZ, 0.5
SO, 0, 1
Feed hold at any point during the run, either with the feed hold input or the UI STOP button. This will present the RESUME/QUIT options. Before this change, resume would not lead to a prompt for authorization. After this change, resume will lead to a single prompt for authorization.  