### PR TITLE
Add the "dev-build.sh" script included in the fabmo rpi image to the repo

### DIFF
--- a/build_scripts/dev-build.sh
+++ b/build_scripts/dev-build.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# Builds my current dev version ... need to have branch identified right!!!
+
+clear
+echo "==> Building dev version"
+cd /
+echo "--> ... be at root"
+echo "--> ... clearing all Fabmo dirs"
+
+sudo systemctl stop fabmo
+echo "--> ... Stopped fabmo service"
+
+sudo rm -rf /fabmo
+sudo rm -rf /opt/fabmo
+echo
+
+echo "--> Cloning current version of FabMo Engine from GitHub"
+cd /
+sudo git clone https://github.com/fabmo/fabmo-engine ./fabmo
+
+cd /fabmo
+echo
+
+echo "--> Setting Branch"
+sudo git checkout master
+git status
+echo
+
+echo "--> Ready for npm install"
+sudo npm install
+
+echo
+echo "================================================="
+echo "==> Seem to have done it ... "
+echo "STARTING FabMo!"
+echo "================================== check path! =="
+echo
+sudo npm run dev
+


### PR DESCRIPTION
I went looking for the "dev-build" script used to bootstrap fabmo onto a rpi and couldn't find it in git anywhere, so wanted to get it checked in. This version comes from 2022_rpi4-23-Bullseye-Dev-8G.zip