### PR TITLE
Bump node_module adm-zip from ^0.4.14 to 0.5.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"unsafe-perm": true
 	},
 	"dependencies": {
-		"adm-zip": "^0.4.14",
+		"adm-zip": "0.5.9",
 		"async": "1.4.x",
 		"backbone": "1.4.0",
 		"bonjour": "jlucidar/bonjour",


### PR DESCRIPTION
I ran all dev-checks, tested feed hold in motion, feed hold directly after resume, seemed normal. Feed hold during pause still does not work (known bug). Re ran dev checks with authorize enabled, tested that authorize is required after resume. Ran a gcode file, checked feed hold and authorize within gcode file. 

Checked the USB IP retrieval function. The zip file is not populated (known bug) but the html, network.txt, shopbotsupport.txt, and shopbotsupport.zip are created/populated.

I chose to forgo the caret on the version. Rob and I have been discussing whether to lockdown versions or not. Figured I would try it on this one and see how it feels. 