### PR TITLE
Clean up data export directory name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get -qq update && \
     net-tools \ 
     isc-dhcp-server \
     build-essential \
+    zip \
     libreadline-dev
 
 

--- a/bin/collect_and_export_data_to_usb_drive
+++ b/bin/collect_and_export_data_to_usb_drive
@@ -4,9 +4,8 @@ use warnings;
 use strict;
 use File::Temp;
 
-my $TEMP = File::Temp->newdir();
-my $REPORT_ID =
-  "fabmo-" . `cat /etc/machine-id` . "-" . `date +%Y.%-m.%-d%H%M%S`;
+my $TEMP             = File::Temp->newdir();
+my $REPORT_ID        = build_report_id();
 my $REPORT_BUILD_DIR = $TEMP . "/" . $REPORT_ID;
 mkdir($REPORT_BUILD_DIR);
 
@@ -193,3 +192,14 @@ sub logmsg {
     my $arg = shift;
     system( "/usr/bin/logger", $arg );
 }
+
+sub build_report_id {
+    my $machine_id = `cat /etc/machine-id`;
+    chomp $machine_id;
+
+    my $datestamp = `date +%Y.%-m.%-d%H%M%S`;
+    chomp $datestamp;
+
+    return join( "-", "fabmo", $machine_id, $datestamp );
+}
+


### PR DESCRIPTION
The way we were constructing the debugging dump's directory name didn't
properly drop trailing newlines, resulting in a zip file windows didn't
accept.

Add zip to our Dockerfile to enable testing of collect_and_export_data_to_usb_drive

Fixed #923