### PR TITLE
If G2 dies while a file is running shut off output 4

### DIFF
--- a/machine.js
+++ b/machine.js
@@ -920,6 +920,7 @@ Machine.prototype.setState = function(source, newstate, stateinfo) {
 				this.status.resumeFlag = false;
 				break;
 			case 'dead':
+				this.status.out4 = 0;
 				log.error('G2 is dead!');
 				break;
 			default:


### PR DESCRIPTION
If G2 dies while is file is running output 4 does not get shut off. Once you do a reboot output 4 will still be on. I triggered this by starting a cut file and then using the interlock input (which is currently broken) and it will cause a G2 exception to occur. Solves https://github.com/FabMo/FabMo-Engine/issues/858.