### PR TITLE
Display line number

### DIFF
--- a/dashboard/build/index.html
+++ b/dashboard/build/index.html
@@ -455,6 +455,11 @@
           <p class="elapsed_time_text">0s</p>
         </div>
         <div class="percent_comp">10%</div>
+        <div class="line_number">
+          <p class="line_number_label">line:
+          <p>
+          <p class="line_number_text">0</p>
+        </div>
       </div>
       <div class='pauseJob-wrapper'>
         <div class='pauseJob fabmo-pause-button '>

--- a/dashboard/static/css/style.css
+++ b/dashboard/static/css/style.css
@@ -1202,11 +1202,10 @@ ul.off-canvas-list li a, ul.off-canvas-list li.no-link {
 .elapsed_time{
 	font-family: 'source_sans_proextralight';
     display: inline-flex;
-    margin-right: auto;
+    margin-right: 50px;
     margin-left: auto;
     text-align: center;
     color:#F0F0F0;
-	margin-right: 50px;
 }
 
 .elapsed_time_small{

--- a/dashboard/static/css/style.css
+++ b/dashboard/static/css/style.css
@@ -1205,7 +1205,8 @@ ul.off-canvas-list li a, ul.off-canvas-list li.no-link {
     margin-right: auto;
     margin-left: auto;
     text-align: center;
-    color:#F0F0F0
+    color:#F0F0F0;
+	margin-right: 50px;
 }
 
 .elapsed_time_small{
@@ -1225,6 +1226,15 @@ ul.off-canvas-list li a, ul.off-canvas-list li.no-link {
 	font-size: 12px;
 	margin: 0;
 	display: inline;
+}
+
+.line_number{
+	font-family: 'source_sans_proextralight';
+    display: inline-flex;
+    margin-right: auto;
+    margin-left: auto;
+    text-align: center;
+    color:#F0F0F0
 }
 
 

--- a/dashboard/static/js/libs/fabmoui.js
+++ b/dashboard/static/js/libs/fabmoui.js
@@ -311,6 +311,7 @@ FabMoUI.prototype.updateStatusContent = function(status){
 			$('.percent_comp').text(percent + '%');
 			$('.horizontal_fill').css('width', percent + '%');
             $('.elapsed_time_text').text(time_elapsed_text);
+			$('.line_number_text').text(status.line);
 		$(that.progress_selector).css("width",prog.toString() + "%");
 	}
 	else {

--- a/dashboard/static/js/libs/fabmoui.js
+++ b/dashboard/static/js/libs/fabmoui.js
@@ -311,7 +311,7 @@ FabMoUI.prototype.updateStatusContent = function(status){
 			$('.percent_comp').text(percent + '%');
 			$('.horizontal_fill').css('width', percent + '%');
             $('.elapsed_time_text').text(time_elapsed_text);
-			$('.line_number_text').text(status.line);
+			$('.line_number_text').text(status.line - 19);
 		$(that.progress_selector).css("width",prog.toString() + "%");
 	}
 	else {

--- a/dashboard/static/js/libs/fabmoui.js
+++ b/dashboard/static/js/libs/fabmoui.js
@@ -306,12 +306,20 @@ FabMoUI.prototype.updateStatusContent = function(status){
 		}
 		this.progress = percent;
 
+		//Status.line does not show the line being ran, it is off by 19 lines for some reason
+		var comped_line = status.line - 19;
+
+		//If the comp makes line go below zero, say its 0
+		if(comped_line <= 0){
+			comped_line = 0;
+		}
+
 			$('.radial_progress').hide();
    			$('.load_container').show();
 			$('.percent_comp').text(percent + '%');
 			$('.horizontal_fill').css('width', percent + '%');
             $('.elapsed_time_text').text(time_elapsed_text);
-			$('.line_number_text').text(status.line - 19);
+			$('.line_number_text').text(comped_line);
 		$(that.progress_selector).css("width",prog.toString() + "%");
 	}
 	else {


### PR DESCRIPTION
The line number of the currently running file is displayed in the footer near the progress bar. This fixes https://github.com/FabMo/FabMo-Engine/issues/930. It is a known issue that status.line does not reflect the line that is actually being ran. I compensated it by 19 lines which seemed to be correct on a short program, <100 lines, and a long program, >10000 lines. This is what you should expect to see during testing.


![Screenshot 2022-06-20 181255](https://user-images.githubusercontent.com/73403072/174683741-3b47bdf7-6288-4279-9cb4-39c34e1bf3de.png)

