### PR TITLE
Units are now displayed in the DRO, open to suggestions

### DIFF
--- a/dashboard/build/index.html
+++ b/dashboard/build/index.html
@@ -96,7 +96,9 @@
           <!-- ***** Tool Position Section ***** -->
           
           <section class="right DRO-button show-for-small-up fabmo-status" id="right-position-container">
-            <div id="dro-tab" title="Click to toggle large Location Display"></div>
+            <div id="dro-tab" title="Click to toggle large Location Display">
+              <div id="display-units">Units:&nbsp;<span class="units"></span> </div>
+            </div>
             <div  class="sm-axes"><strong>
               <div class="xaxis machine-pos" ><label>X : &nbsp;<span class="posx">X.XXX</span></label></div>
               <div class="yaxis machine-pos" ><label>Y : &nbsp;<span class="posy">Y.YYY</span></label></div>

--- a/dashboard/static/css/style.css
+++ b/dashboard/static/css/style.css
@@ -216,6 +216,13 @@ box-shadow: 0px 2px 3px 0px rgba(235,228,235,1);
 	transition: all 0.2s;
 }
 
+#display-units {
+	text-align: left;
+	margin-left: 10px;
+	font-weight: bold;
+	font-size: 14px;
+}
+
 #right-position-container {
 	cursor: pointer;
 	background-color: #931B14;


### PR DESCRIPTION
Units are now displayed in the upper right DRO. Ran the dev-checks/unit tests and everything seems normal. Definitely open to suggestions on location/text size etc.

![Capture](https://user-images.githubusercontent.com/73403072/174875020-3c71c868-9bb6-4de3-a50b-78a98cca341a.PNG)

Fixes https://github.com/FabMo/FabMo-Engine/issues/957, https://github.com/FabMo/FabMo-Engine/issues/869 and arguably fixes https://github.com/FabMo/FabMo-Engine/issues/940. 