### PR TITLE
Unit display was linked to the yellow DRO tab, not anymore.

### DIFF
--- a/dashboard/build/index.html
+++ b/dashboard/build/index.html
@@ -96,9 +96,8 @@
           <!-- ***** Tool Position Section ***** -->
           
           <section class="right DRO-button show-for-small-up fabmo-status" id="right-position-container">
-            <div id="dro-tab" title="Click to toggle large Location Display">
-              <div id="display-units">Units:&nbsp;<span class="units"></span> </div>
-            </div>
+            <div id="display-units">Units:&nbsp;<span class="units"></span> </div>
+            <div id="dro-tab" title="Click to toggle large Location Display"></div>
             <div  class="sm-axes"><strong>
               <div class="xaxis machine-pos" ><label>X : &nbsp;<span class="posx">X.XXX</span></label></div>
               <div class="yaxis machine-pos" ><label>Y : &nbsp;<span class="posy">Y.YYY</span></label></div>

--- a/dashboard/static/css/style.css
+++ b/dashboard/static/css/style.css
@@ -217,10 +217,13 @@ box-shadow: 0px 2px 3px 0px rgba(235,228,235,1);
 }
 
 #display-units {
+	position: absolute;
+	top: 2px;
+	left: 5px;
+	width: 0;
 	text-align: left;
-	margin-left: 10px;
 	font-weight: bold;
-	font-size: 14px;
+	font-size: 17px;
 }
 
 #right-position-container {


### PR DESCRIPTION
Fixes https://github.com/FabMo/FabMo-Engine/issues/963. I mistakenly put the unit display within the dro-tab div. That was causing it to move left and right when the dro-tab was clicked. It is now its own div, and positioned accordingly. Ran dev-checks and unit tests. Set all coordinates to 10,000 to ensure that as the numbers get larger, they do not get closer to the units display.