### PR TITLE
Fix macro saving

### DIFF
--- a/macros.js
+++ b/macros.js
@@ -186,6 +186,8 @@ var update = function (id, macro, callback) {
         // Here, we're updating an existing macro
         // We only update fields that were provided in the macro passed in
         // Other fields, we leave alone.
+        // Tried moving this function to outer scope but it caused issues with
+        // saving macros, will address later
         // eslint-disable-next-line no-inner-declarations
         function savemacro(id, callback) {
             old_macro.name = macro.name || old_macro.name;


### PR DESCRIPTION
Addresses https://github.com/FabMo/FabMo-Engine/issues/1019.
I have tested in the following ways:
Saving macros with the "save" button, and with the "save and close" button
ran several cut files, stopping and interlocking occasionally.
ran the dev-checks in the usual manner
used the manual keypad in both modes, changing the move speed works, zeroing in the keypad works
Executed jobs directly from editor
Submitted jobs and ran them
Used the job manager to submit, resubmit, and delete files, or retrieve them from history.
Use settings page to change fields and ensure they still work/no exceptions. I tested machine profile, default unit system, chordal tolerance, junction integration time, log level, status report interval, update g2 firmware from file, backup configuration, restore the configuration, changed machine envelope, z-lift height, spindle delay, Manual control settings, Safety settings, AP mode button settings, quit button settings, driver settings, Axes settings, input settings
User management section of Users works.

Found a bug in the process of testing. I forgot to test setting machine name during last PR. It creates an uncaught exception on master branch.