### PR TITLE
Gcode runtime: Check if end of program before sending m30

### DIFF
--- a/runtime/gcode/gcode.js
+++ b/runtime/gcode/gcode.js
@@ -189,11 +189,6 @@ GCodeRuntime.prototype._handleStateChange = function (stat) {
             // may change someday in the future on the g2core end, so we may end up revisiting this.
             // OTOH, an extra M30 should not cause a problem.
 
-            // As of 04/04/2022 the extra m30 seems to be a problem.
-            // Before commenting out this.driver.sendM30, files would end whenever a stat 3 was received
-            // which is not always at the end of the file. If the operator forgets to add an m30
-            // to the end of their file then FabMo will stall and show an empty footer, requiring ESC key to be hit.
-            // I am writing that up as a seperate enhancement issue
             this._changeState("stopped");
             if (this._file_or_stream_in_progress) {
                 this._file_or_stream_in_progress = false;

--- a/runtime/gcode/gcode.js
+++ b/runtime/gcode/gcode.js
@@ -196,8 +196,10 @@ GCodeRuntime.prototype._handleStateChange = function (stat) {
             // I am writing that up as a seperate enhancement issue
             this._changeState("stopped");
             if (this._file_or_stream_in_progress) {
-                //this.driver.sendM30();
                 this._file_or_stream_in_progress = false;
+            }
+            if (this.machine.status.line >= this.machine.status.nb_lines) {
+                this.driver.sendM30();
             }
             break;
         default:
@@ -211,7 +213,7 @@ GCodeRuntime.prototype.runStream = function (st) {
     if (this.machine) {
         this.machine.setState(this, "running");
     }
-
+    this.machine.status.line = 1;
     var manualPrime =
         this.machine.status.nb_lines < this.driver.primedThreshold;
     var ln = new LineNumberer();


### PR DESCRIPTION
This PR addresses issue https://github.com/FabMo/FabMo-Engine/issues/847 and issue https://github.com/FabMo/FabMo-Engine/issues/994. I achieved this by comparing the current line to the end of program line whenever a stat 3 is received during the gcode runtime. 

For testing:
-Ran the dev-checks
-Changed configuration distance mode from absolute to relative, footer did not stay on screen
-Ran the test file below over and over. Before my change it would sometimes end prematurely and always display empty footer if there was no m30 at the end. Now m30 will not occur until the end of the program, even if there is no m30 in the program.

Make sure to run test file on the simulator. I used unusually large z heights to track line numbers and position in the program.

Test file:
g20
g90
g0 x0 y0
s1000 m3
f350
g1 x10
g1 y10
g1 x0
g1 y0
g0 z13
m5

g04 p10.0

g20
g90
g0 x0 y0
s1000 m3
f350
g1 x10
g1 y10
g1 x0
g1 y0
g0 z27
m5

g04 p10.0

g20
g90
g0 x0 y0
s1000 m3
f350
g1 x10
g1 y10
g1 x0
g1 y0
g0 z41
m5

g04 p10.0

g20
g90
g0 x0 y0
s1000 m3
f350
g1 x10
g1 y10
g1 x0
g1 y0
g0 z55
m5

g04 p10.0

g20
g90
g0 x0 y0
s1000 m3
f350
g1 x10
g1 y10
g1 x0
g1 y0
g0 z69
m5

g04 p10.0

g20
g90
g0 x0 y0
s1000 m3
f350
g1 x10
g1 y10
g1 x0
g1 y0
g0 z83
m5

g04 p10.0

g20
g90
g0 x0 y0
s1000 m3
f350
g1 x10
g1 y10
g1 x0
g1 y0
g0 z97
m5

g04 p10.0