### PR TITLE
edit wording of custom macro naming

### DIFF
--- a/dashboard/apps/macro_manager.fma/index.html
+++ b/dashboard/apps/macro_manager.fma/index.html
@@ -11,13 +11,13 @@
         <nav class="top-bar" data-topbar role="navigation">
           <ul class="title-area">
             <li class="name">
-              <h1><a id="app-header" href="">Macros</a></h1>
+              <h1><a id="app-header" href="">Custom Macros</a></h1>
             </li>
             <li class="toggle-topbar"><a href="#"><span>Menu</span></a></li>
           </ul>
           <section class="top-bar-section">
             <ul class="left">
-              <li><a id="macro-new" href="#">Create new macro...</a></li>
+              <li><a id="macro-new" href="#">Create new custom macro...</a></li>
             </ul>
           </section>
         </nav>
@@ -26,7 +26,7 @@
                 <table class="small-12 columns" style="width:100%" id="macro_table">
                 <tr>
                         <th></th>
-                        <th>Macro #</th>
+                        <th>Custom #</th>
                         <th>Name</th>
                         <th>Description</th>
                         <th></th>

--- a/dashboard/apps/macro_manager.fma/package.json
+++ b/dashboard/apps/macro_manager.fma/package.json
@@ -1,5 +1,5 @@
 {
-	"name":"Macros",
+	"name":"Custom Macros",
 	"main":"./index.html",
 	"icon":"icon.png",
 	"icon_color":"#313366",
@@ -8,5 +8,5 @@
 	"author":"Ryan Sturmer",
 	"website":"http://shopbottools.com",
 	"id":"macros",
-    "description":"System app for managing and running macros"
+    "description":"System app for managing and running custom macros"
 }

--- a/dashboard/build/index.html
+++ b/dashboard/build/index.html
@@ -171,7 +171,7 @@
             <li><a href="#/app/def" id="icon_def" title="Def"><span>Home</span></a></li>
             <li><a href="#/app/job-manager" id="icon_jobs" title="Job Manager"><span>Job Manager</span></a></li>
             <li><a href="#/app/editor" id="icon_editor" title="Editor"><span>Editor</span></a></li>
-            <li><a href="#/app/macros" id="icon_folder" title="Macros"><span>Macros</span></a></li>
+            <li><a href="#/app/macros" id="icon_folder" title="Custom Macros"><span>Macros</span></a></li>
             <li><a href="#/app/apps" id="icon_apps" title="Apps"><span>Apps</span></a></li>
             <li><a href="#/app/video" id="icon_video" title="Video"><span>Video</span></a></li>
             <li><a href="#/app/config" id="icon_settings" title="Configuration"><span>Configuration</span></a></li>


### PR DESCRIPTION
some subtle changes to go along with subtle changes in Sb4 to make the C commands a little more intuitive by adding the "C" in custom to the naming convention.