### PR TITLE
Restore default scrolling to fix scrolling in macros

### DIFF
--- a/dashboard/static/css/style.css
+++ b/dashboard/static/css/style.css
@@ -10,8 +10,6 @@ body {
     font-family: 'source_sans_proregular';
     height: 100%;
     width: 100%;
-    overflow-x: hidden;
-    overflow-y: hidden;
     background-color: #eee;
 }
 


### PR DESCRIPTION
This turns scrolling back on in the Macro Manager. I had disabled it while trying to get control of scrolling in Sb4. For most of the other apps, scroll behavior is set in the individual app, so only the Macro Manager was affected. Should be right for all now and ok in Sb4.