### PR TITLE
Improve getting new location using system variables after setting or zeroing location

### DIFF
--- a/config/opensbp_config.js
+++ b/config/opensbp_config.js
@@ -69,6 +69,9 @@ OpenSBPConfig.prototype.update = function (data, callback, force) {
         return callback(e);
     }
     // Update Jerk Values to current G2, no longer saved in g2.json
+    ////## Maybe skip these if just doing temp vars?
+    //     ... not clear why called for a variable updates
+
     if ("xy_maxjerk" in this._cache) {
         config.machine.machine.driver.command({
             xjm: this._cache["xy_maxjerk"],

--- a/dashboard/static/css/style.css
+++ b/dashboard/static/css/style.css
@@ -10,8 +10,6 @@ body {
     font-family: 'source_sans_proregular';
     height: 100%;
     width: 100%;
-    overflow-x: hidden;
-    overflow-y: hidden;
     background-color: #eee;
 }
 

--- a/g2.js
+++ b/g2.js
@@ -433,18 +433,6 @@ G2.prototype.requestStatusReport = function (callback) {
     this.command({ sr: null });
 };
 
-G2.prototype.requestStatusReportWrapper = async function (input) {
-    return await new Promise((resolve, reject) => {
-        this.requestStatusReport(input, function (err, result) {
-            if (err) {
-                reject(err);
-            } else {
-                resolve(result);
-            }
-        });
-    });
-};
-
 // Called for every chunk of data returned from G2
 G2.prototype.onData = function (data) {
     var t = new Date().getTime(); // Get current time for logging

--- a/g2.js
+++ b/g2.js
@@ -248,16 +248,17 @@ G2.prototype._createCycleContext = function () {
     // M0 sets G2 to 'File Stop' stat:3; thus avoids accidentally starting in stat:4
     // ... these conditions are exited when in machine as it goes back to idle
     ////## S1000 is default for spindle speed so that m3 (and SO,1,1) will work correctly w/delay w/o speed
+    ////## M0 makes sure we don't get a spurious stat:4 (needs to be in first 4 commands or vulnerable)
     ////## TODO: create default variable for S-value for VFD spindle control, just a dummy here now
     ////## TODO: fix this kludge to get the current_runtime !
     if (global.CUR_RUNTIME != "[IdleRuntime]") {
         log.debug("PREPEND to cycle - " + global.CUR_RUNTIME);
         st.write(
-            "N1 G90\n" +
-                "N2 S1000\n" +
+            "N1 M0\n" +
+                "N2 G90\n" +
                 "N3 G61\n" +
                 "N4 M100 ({out4:1})\n" +
-                "N5 M0\n"
+                "N5 S1000\n"
         );
     }
 

--- a/g2.js
+++ b/g2.js
@@ -433,6 +433,18 @@ G2.prototype.requestStatusReport = function (callback) {
     this.command({ sr: null });
 };
 
+G2.prototype.requestStatusReportWrapper = async function (input) {
+    return await new Promise((resolve, reject) => {
+        this.requestStatusReport(input, function (err, result) {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(result);
+            }
+        });
+    });
+};
+
 // Called for every chunk of data returned from G2
 G2.prototype.onData = function (data) {
     var t = new Date().getTime(); // Get current time for logging

--- a/g2.js
+++ b/g2.js
@@ -245,10 +245,9 @@ G2.prototype._createCycleContext = function () {
     // Items that need to be pre-pended for all normal motions cycles.
     // So, if we are not in IdleRuntime, then ...
     // Set absolute, spindle speed default, units, and turn on output 4 & ...
-    // M0 sets G2 to 'File Stop' stat:3; thus avoids accidentally starting in stat:4
+    // M0 sets G2 to 'File Stop' stat:3; thus avoids accidentally starting in stat:4 (needs to be in first 4 commands or vulnerable)
     // ... these conditions are exited when in machine as it goes back to idle
     ////## S1000 is default for spindle speed so that m3 (and SO,1,1) will work correctly w/delay w/o speed
-    ////## M0 makes sure we don't get a spurious stat:4 (needs to be in first 4 commands or vulnerable)
     ////## TODO: create default variable for S-value for VFD spindle control, just a dummy here now
     ////## TODO: fix this kludge to get the current_runtime !
     if (global.CUR_RUNTIME != "[IdleRuntime]") {

--- a/runtime/manual/driver.js
+++ b/runtime/manual/driver.js
@@ -324,8 +324,6 @@ ManualDriver.prototype.set = function (pos) {
                         console.log(key);
                         switch (key) {
                             case "X":
-                                //axes[0] = pos[key];
-                                //offsets.call(this, axes);
                                 toSet.g55x = Number(
                                     (MPO.x * unitConv - pos[key]).toFixed(5)
                                 );

--- a/runtime/manual/driver.js
+++ b/runtime/manual/driver.js
@@ -18,6 +18,8 @@ var util = require("util");
 var events = require("events");
 var Q = require("q");
 
+const { offsets } = require("../opensbp/commands/location");
+
 // Parameters related to filling the queue, motion, etc.
 // These are fussy.
 var T_RENEW = 300;
@@ -308,6 +310,7 @@ ManualDriver.prototype.goto = function (pos) {
 ManualDriver.prototype.set = function (pos) {
     var toSet = {};
     var unitConv;
+    const axes = []; // X=0
     if (this.driver.status.unit === "in") {
         // inches
         unitConv = 0.039370079;
@@ -324,9 +327,11 @@ ManualDriver.prototype.set = function (pos) {
                         console.log(key);
                         switch (key) {
                             case "X":
-                                toSet.g55x = Number(
-                                    (MPO.x * unitConv - pos[key]).toFixed(5)
-                                );
+                                axes[0] = pos[key];
+                                offsets.call(this, axes);
+                                // toSet.g55x = Number(
+                                //     (MPO.x * unitConv - pos[key]).toFixed(5)
+                                // );
                                 break;
                             case "Y":
                                 toSet.g55y = Number(

--- a/runtime/manual/driver.js
+++ b/runtime/manual/driver.js
@@ -18,8 +18,6 @@ var util = require("util");
 var events = require("events");
 var Q = require("q");
 
-const { offsets } = require("../opensbp/commands/location");
-
 // Parameters related to filling the queue, motion, etc.
 // These are fussy.
 var T_RENEW = 300;
@@ -310,7 +308,6 @@ ManualDriver.prototype.goto = function (pos) {
 ManualDriver.prototype.set = function (pos) {
     var toSet = {};
     var unitConv;
-    const axes = []; // X=0
     if (this.driver.status.unit === "in") {
         // inches
         unitConv = 0.039370079;
@@ -327,11 +324,11 @@ ManualDriver.prototype.set = function (pos) {
                         console.log(key);
                         switch (key) {
                             case "X":
-                                axes[0] = pos[key];
-                                offsets.call(this, axes);
-                                // toSet.g55x = Number(
-                                //     (MPO.x * unitConv - pos[key]).toFixed(5)
-                                // );
+                                //axes[0] = pos[key];
+                                //offsets.call(this, axes);
+                                toSet.g55x = Number(
+                                    (MPO.x * unitConv - pos[key]).toFixed(5)
+                                );
                                 break;
                             case "Y":
                                 toSet.g55y = Number(

--- a/runtime/opensbp/commands/location.js
+++ b/runtime/opensbp/commands/location.js
@@ -40,15 +40,7 @@ function offsets(args, callback) {
             if (args[0] !== undefined) {
                 // offset X location
                 setVA_G2.g55x = Number((MPO.x * unitConv - args[0]).toFixed(5));
-                log.debug(
-                    "   NEW g55X" + JSON.stringify(setVA_G2.g55x)
-
-                    //      +
-                    //      "  MPO.x = " +
-                    //      MPO.x +
-                    //      " args[0] = " +
-                    //      args[0]
-                );
+                log.debug("   NEW g55X" + JSON.stringify(setVA_G2.g55x));
                 updtG55axes += "X" + setVA_G2.g55x + " "; // start building axis request for G10 call
                 this.cmd_posx = this.posx = args[0];
             }
@@ -91,37 +83,14 @@ function offsets(args, callback) {
 
             if (updtG55axes != "") {
                 try {
-                    //this.CUR_RUNTIME.machine.executeRuntimeCode("gcode", ("G10 L2 P2 " + updtG55axes));
-                    //            await this.CUR_RUNTIME.emit_gcode(
-                    //                "{" + updtG55axes + "}\nM0"
-                    //            );
-                    //this.CUR_RUNTIME.machine.executeRuntimeCode("gcode", ("G10 L2 P2 " + updtG55axes));
                     this.CUR_RUNTIME.emit_gcode("G10 L2 P2 " + updtG55axes);
-
-                    //    log.debug("writing > M0");
-                    //    this.CUR_RUNTIME.emit_gcode("M0");
-
-                    //this.CUR_RUNTIME.driver._write("G10 L2 P2 " + updtG55axes); //NOPE here
                     this.CUR_RUNTIME.gcodesPending = false;
                     await config.driver.setManyWrapper(setVA_G2); // syncs FabMo and G2 configs
                     log.debug("##-> FINISHED AWAIT CONFIG SYNC - LOWER");
+                    //log.debug("##-> FINISHED setup for G55 Offseting");
+                    log.debug("writing > M0");
+                    this.CUR_RUNTIME.emit_gcode("M0");
 
-                    log.debug("##-> FINISHED setup for G55 Offseting");
-                    //                log.debug("repreq > pos");
-                    //                this.CUR_RUNTIME.driver._write("{mpo:null}");
-                    //                this.CUR_RUNTIME.driver._write("{pos:null}");
-                    this.CUR_RUNTIME.driver._write("M0");
-                    //this.gcodesPending = true;
-
-                    // log.debug("Ready for Status Report request ... waiting");
-                    // await this.CUR_RUNTIME.driver.requestStatusReportWrapper(function(report) {
-                    //     log.debug("report = " + JSON.stringify(report));
-                    //     callback();
-                    // });
-
-                    // This command updates G55 settings in FabMo and makes sure they are synced with G2.
-                    // ... They have already been redundantly (temporarily) set in G2 by the G10 call.
-                    //await this.CUR_RUNTIME.driver.requestStatusReport("stat");
                     if (callback) {
                         // kludge to deal with calls coming from manual driver
                         callback(
@@ -151,10 +120,7 @@ async function machineLoc(args, callback) {
         //    log.debug("##-> FINISHED AWAIT CONFIG - UPPER");
         // await this.driver.requestStatusReport();
         try {
-            await this.emit_gcode(
-                "G28.3 " + updtMachineLoc,
-                offsets.call(this, args, callback)
-            );
+            await this.emit_gcode("G28.3 " + updtMachineLoc);
             if (callback) {
                 callback(offsets.call(this, args, callback));
             }

--- a/runtime/opensbp/commands/location.js
+++ b/runtime/opensbp/commands/location.js
@@ -83,6 +83,7 @@ function offsets(args, callback) {
 
             if (updtG55axes != "") {
                 try {
+                    await machineLoc(args);
                     this.CUR_RUNTIME.emit_gcode("G10 L2 P2 " + updtG55axes);
                     this.CUR_RUNTIME.gcodesPending = false;
                     await config.driver.setManyWrapper(setVA_G2); // syncs FabMo and G2 configs
@@ -110,8 +111,8 @@ function offsets(args, callback) {
 
 // Setting Machine Base Location to Zero or other Value
 //   * This function called first by VA for case of also having G55 Offsets (lower register)
-async function machineLoc(args, callback) {
-    log.debug("##-> STARTING machineLoc - UPPER");
+async function machineLoc(args) {
+    log.debug("##-> STARTING machineLoc - UPPER > " + args);
 
     let updtMachineLoc = "X0";
     if (updtMachineLoc != "") {
@@ -120,13 +121,15 @@ async function machineLoc(args, callback) {
         //    log.debug("##-> FINISHED AWAIT CONFIG - UPPER");
         // await this.driver.requestStatusReport();
         try {
-            await this.emit_gcode("G28.3 " + updtMachineLoc);
-            if (callback) {
-                callback(offsets.call(this, args, callback));
-            }
+            await this.CUR_RUNTIME.emit_gcode("G28.3 " + updtMachineLoc);
+            this.CUR_RUNTIME.emit_gcode("M0");
+            // if (callback) {
+            //     callback(offsets.call(this, args, callback));
+            //     callback(offsets.call(this, args, callback));
+            // }
         } catch (error) {
             log.debug(error);
-            callback(error);
+            //callback(error);
         }
     }
 }

--- a/runtime/opensbp/commands/location.js
+++ b/runtime/opensbp/commands/location.js
@@ -1,0 +1,106 @@
+var log = require("../../../log").logger("sbp");
+var config = require("../../../config");
+
+// location.js provides 2 functions for the common manipulation of location
+// These functions serve the VA Command, all the ZERO Commands, and calls to "Set Location" or
+//     "Zero" an axis in the manual Keypad
+// These functions are done with raw MPO values for location to be most universal
+
+// NOTES:
+
+// {"mpo":""}  return absolute machine positions fox XYZABC axes.
+// !!!!!!!!!!!! Always in mm, regardless of G20/G21 setting
+
+// {"pos":""}  return work coordinate positions fox XYZABC axes.
+//              In mm or inches depending on G20 or G21
+
+// {"g55":""}  returns the current offset to the UCS origin
+//              In mm or inches depending on G20 or G21
+
+function offsets(args, callback) {
+    this.driver.get(
+        //machine.driver??
+        "mpo",
+
+        async function (err, MPO) {
+            var setVA_G2 = {};
+            var unitConv = 1;
+            var updtG55axes = "";
+            if (this.driver.status.unit === "in") {
+                //machine.driver
+                // inches
+                unitConv = 0.039370079;
+            }
+            // Process Lower Register for Required G55 Offset
+            if (args[0] !== undefined) {
+                // //X location
+                setVA_G2.g55x = Number((MPO.x * unitConv - args[0]).toFixed(5));
+                log.debug(
+                    "    g55X" +
+                        JSON.stringify(setVA_G2.g55x) +
+                        "  MPO.x = " +
+                        MPO.x +
+                        " args[0] = " +
+                        args[0]
+                );
+                updtG55axes += "X" + setVA_G2.g55x + " "; // start building axis request for G10 call
+                this.cmd_posx = this.posx = args[0];
+            }
+            if (args[1] !== undefined) {
+                //Y location
+                setVA_G2.g55y = Number((MPO.y * unitConv - args[1]).toFixed(5));
+                updtG55axes += "Y" + setVA_G2.g55y + " ";
+                this.cmd_posy = this.posy = args[1];
+            }
+            if (args[2] !== undefined) {
+                //Z location
+                setVA_G2.g55z = Number((MPO.z * unitConv - args[2]).toFixed(5));
+                updtG55axes += "Z" + setVA_G2.g55z + " ";
+                this.cmd_posz = this.posz = args[2];
+            }
+            if (args[3] !== undefined) {
+                //A location
+                setVA_G2.g55a = Number(
+                    (MPO.a * 1.0 /*unitConv*/ - args[3]).toFixed(5) // no units for ABC
+                );
+                updtG55axes += "A" + setVA_G2.g55a + " ";
+                this.cmd_posa = this.posa = args[3];
+            }
+            if (args[4] !== undefined) {
+                //B location
+                setVA_G2.g55b = Number(
+                    (MPO.b * 1.0 /*unitConv*/ - args[4]).toFixed(5)
+                );
+                updtG55axes += "B" + setVA_G2.g55b + " ";
+                this.cmd_posb = this.posb = args[4];
+            }
+            if (args[5] !== undefined) {
+                //C location
+                setVA_G2.g55c = Number(
+                    (MPO.c * 1.0 /*unitConv*/ - args[5]).toFixed(5)
+                );
+                updtG55axes += "C" + setVA_G2.g55c + " ";
+                this.cmd_posc = this.posc = args[5];
+            }
+
+            // Make G10 update request for G2 if values present
+            if (updtG55axes != "") {
+                log.debug("G10 L2 P2 " + updtG55axes);
+                this.stream.write("G10 L2 P2 " + updtG55axes);
+                //this.emit_gcode("G10 L2 P2 " + updtG55axes);
+            }
+            // Update the FabMo config system including redundant post to G2
+            try {
+                await config.driver.setManyWrapper(setVA_G2);
+                if (callback) {
+                    // kludge to deal with calls coming from manual driver
+                    callback();
+                }
+            } catch (error) {
+                callback(error);
+            }
+        }.bind(this)
+    );
+}
+
+exports.offsets = offsets;

--- a/runtime/opensbp/commands/location.js
+++ b/runtime/opensbp/commands/location.js
@@ -1,44 +1,43 @@
 var log = require("../../../log").logger("sbp");
 var config = require("../../../config");
 
-// location.js provides 2 functions for the common manipulation of location
-// These functions serve the VA Command, all the ZERO Commands, and calls to "Set Location" or
-//     "Zero" an axis in the manual Keypad
-// These functions are done with raw MPO values for location to be most universal
-
+// location.js provides 2 functions for the manipulation of location by several different commands
+// These functions serve the VA Command, all the ZERO Commands, and ST
+// ... Calls from the manual Keypad to to "Set Location" or "Zero" are still handled from there because of its quirkiness
+// These functions are initiated with raw MPO values for location to be most universal
+// In files, location requests from system variables are based on the immediate update to locations from here
+// ... and do not depend on return of the updated location from G2.
 // NOTES:
-
 // {"mpo":""}  return absolute machine positions fox XYZABC axes.
 // !!!!!!!!!!!! Always in mm, regardless of G20/G21 setting
-
 // {"pos":""}  return work coordinate positions fox XYZABC axes.
 //              In mm or inches depending on G20 or G21
-
 // {"g55":""}  returns the current offset to the UCS origin
 //              In mm or inches depending on G20 or G21
 
-// Process for G55 Offsets
-//   *This function called second in VA if Machine Base Location is also being set (upper register)
-//   ... because the G55 needs to be applied after; full zeroing (ZT) requires both
+// Process G55 Offsets for a location change
+//   * Started first, but this function completed only after Machine Base Location (from upper register) is set with G28.3
+//   ... because the final offset needs to be applied after machine zeroing or location setting (e.g. ZT requires both)
 function offsets(args, callback) {
-    log.debug("##-> GETTING CONFIG.MPO FIRST");
+    log.debug("Initiating location changes by getting CONFIG.MPO");
     //  this.driver.get(
     this.driver.get(
         //machine.driver??
         "mpo",
         async function (err, MPO) {
-            log.debug("##->Then Returning Offset Work as AS ASYNC FUNCTION");
+            log.debug("First part of  Offset Work");
             var setVA_G2 = {};
             var unitConv = 1;
             let updtG55axes = "";
             if (this.CUR_RUNTIME.units === "in") {
-                // kludge for machine.driver
                 // to inches
                 unitConv = 0.039370079;
             }
 
             if (args[0] !== undefined) {
                 // offset X location
+                if (args[6] !== undefined) MPO.x = args[6] / unitConv;
+                //                if (typeof args[6] === "number" && isFinite(args[6])) MPO.x = args[6] / unitConv;  // First handle any G28.3 adjustments from upper register
                 setVA_G2.g55x = Number((MPO.x * unitConv - args[0]).toFixed(5));
                 log.debug("   NEW g55X" + JSON.stringify(setVA_G2.g55x));
                 updtG55axes += "X" + setVA_G2.g55x + " "; // start building axis request for G10 call
@@ -46,18 +45,21 @@ function offsets(args, callback) {
             }
             if (args[1] !== undefined) {
                 //Y location
+                if (args[7] !== undefined) MPO.y = args[7] / unitConv;
                 setVA_G2.g55y = Number((MPO.y * unitConv - args[1]).toFixed(5));
                 updtG55axes += "Y" + setVA_G2.g55y + " ";
                 this.cmd_posy = this.posy = args[1];
             }
             if (args[2] !== undefined) {
                 //Z location
+                if (args[8] !== undefined) MPO.z = args[8] / unitConv;
                 setVA_G2.g55z = Number((MPO.z * unitConv - args[2]).toFixed(5));
                 updtG55axes += "Z" + setVA_G2.g55z + " ";
                 this.cmd_posz = this.posz = args[2];
             }
             if (args[3] !== undefined) {
                 //A location
+                if (args[9] !== undefined) MPO.a = args[9];
                 setVA_G2.g55a = Number(
                     (MPO.a * 1.0 /*unitConv*/ - args[3]).toFixed(5) // no units for rotary
                 );
@@ -66,6 +68,7 @@ function offsets(args, callback) {
             }
             if (args[4] !== undefined) {
                 //B location
+                if (args[10] !== undefined) MPO.b = args[10];
                 setVA_G2.g55b = Number(
                     (MPO.b * 1.0 /*unitConv*/ - args[4]).toFixed(5)
                 );
@@ -74,6 +77,7 @@ function offsets(args, callback) {
             }
             if (args[5] !== undefined) {
                 //C location
+                if (args[11] !== undefined) MPO.c = args[11];
                 setVA_G2.g55c = Number(
                     (MPO.c * 1.0 /*unitConv*/ - args[5]).toFixed(5)
                 );
@@ -81,127 +85,71 @@ function offsets(args, callback) {
                 this.cmd_posc = this.posc = args[5];
             }
 
-            if (updtG55axes != "") {
-                try {
-                    await machineLoc(args);
+            try {
+                await machineLoc(args); // Do the upper register updates first if there are any!
+                log.debug("Completed machine location setting");
+                if (updtG55axes != "") {
                     this.CUR_RUNTIME.emit_gcode("G10 L2 P2 " + updtG55axes);
                     this.CUR_RUNTIME.gcodesPending = false;
                     await config.driver.setManyWrapper(setVA_G2); // syncs FabMo and G2 configs
-                    log.debug("##-> FINISHED AWAIT CONFIG SYNC - LOWER");
-                    //log.debug("##-> FINISHED setup for G55 Offseting");
-                    log.debug("writing > M0");
-                    this.CUR_RUNTIME.emit_gcode("M0");
-
-                    if (callback) {
-                        // kludge to deal with calls coming from manual driver
-                        callback(
-                            log.debug(
-                                "####-> Returning main callback from OFFSETS"
-                            )
-                        );
-                    }
-                } catch (error) {
-                    log.error(error);
                 }
-                return;
+                this.CUR_RUNTIME.emit_gcode("M0");
+                if (callback) {
+                    callback(log.debug("Completed offsets setting"));
+                }
+            } catch (error) {
+                log.error(error);
             }
+            return;
         }
     );
 }
 
-// Setting Machine Base Location to Zero or other Value
-//   * This function called first by VA for case of also having G55 Offsets (lower register)
+// Process Machine Base Location to set Zero or other Value
+//   * This (upper register) function completed first in a location change call before final offsetting (lower register)
 async function machineLoc(args) {
-    log.debug("##-> STARTING machineLoc - UPPER > " + args);
+    log.debug("STARTING machineLoc change - UPPER Register > " + args);
+    // Process Upper Register for Setting Machine Location (needs to be done before offsets if there are any)
+    const subArgs = args.slice(6, 11); // Check to see if there are any values in top of array
+    if (subArgs.some((val) => val !== undefined)) {
+        log.debug("Found Machine Base Changes now being Processed First!");
+        let updtMachineLoc = "";
 
-    let updtMachineLoc = "X0";
-    if (updtMachineLoc != "") {
-        //try {
-        //    await config.driver.setManyWrapper(setVA_G2);
-        //    log.debug("##-> FINISHED AWAIT CONFIG - UPPER");
-        // await this.driver.requestStatusReport();
+        if (args[6] !== undefined) {
+            // set X Machine Base Coordinate
+            updtMachineLoc += "X" + args[6];
+        }
+        if (args[7] !== undefined) {
+            // set Y Machine Base Coordinate
+            updtMachineLoc += "Y" + args[7];
+        }
+        if (args[8] !== undefined) {
+            // set Z Machine Base Coordinate
+            updtMachineLoc += "Z" + args[8];
+        }
+        if (args[9] !== undefined) {
+            // set A Machine Base Coordinate
+            updtMachineLoc += "A" + args[9];
+        }
+        if (args[10] !== undefined) {
+            // set B Machine Base Coordinate
+            updtMachineLoc += "B" + args[10];
+        }
+        if (args[11] !== undefined) {
+            // set C Machine Base Coordinate
+            updtMachineLoc += "C" + args[11];
+        }
+
         try {
             await this.CUR_RUNTIME.emit_gcode("G28.3 " + updtMachineLoc);
             this.CUR_RUNTIME.emit_gcode("M0");
-            // if (callback) {
-            //     callback(offsets.call(this, args, callback));
-            //     callback(offsets.call(this, args, callback));
-            // }
         } catch (error) {
             log.debug(error);
-            //callback(error);
         }
+    } else {
+        log.debug("--> No Machine Base Value Changes in this location command");
     }
 }
-
-//     this.CUR_RUNTIME.driver.get(
-//         //machine.driver??
-//         "mpo",
-
-//         async function (err, MPO) {
-//             log.debug("##->RETURNING this work from UPPER AS ASYNC FUNCTION");
-//             var setVA_G2 = {};
-//             var unitConv = 1;
-//             let updtMachineLoc = "";
-//             if (this.CUR_RUNTIME.units === "in") {
-//                 //machine.driver??
-//                 // to inches
-//                 unitConv = 0.039370079;
-//             }
-
-//             if (args[6] !== undefined) {
-//                 // set X Machine Base Coordinate
-//                 updtMachineLoc += "X" + args[6];
-//                 MPO.x = args[6] / unitConv;
-//             }
-//             if (args[7] !== undefined) {
-//                 //Y Machine Base Coordinate
-//                 updtMachineLoc += "Y" + args[7];
-//                 MPO.y = args[7] / unitConv;
-//             }
-//             if (args[8] !== undefined) {
-//                 //Z Machine Base Coordinate
-//                 updtMachineLoc += "Z" + args[8];
-//                 MPO.z = args[8] / unitConv;
-//             }
-//             if (args[9] !== undefined) {
-//                 //A Machine Base Coordinate
-//                 updtMachineLoc += "A" + args[9];
-//                 MPO.a = args[9]; // / unitConv; // No unit conversion for rotary
-//             }
-//             if (args[10] !== undefined) {
-//                 //B Machine Base Coordinate
-//                 updtMachineLoc += "B" + args[10];
-//                 MPO.b = args[10];
-//             }
-//             if (args[11] !== undefined) {
-//                 //C Machine Base Coordinate
-//                 updtMachineLoc += "C" + args[11];
-//                 MPO.c = args[11];
-//             }
-
-//             // // Make G28.3 update request for G2 if values present
-//             // if (updtMachineLoc != "") {
-//             //     log.debug("G28.3 " + updtMachineLoc);
-//             //     this.CUR_RUNTIME.emit_gcode("G28.3 " + updtMachineLoc);
-//             // }
-
-//             if (updtMachineLoc != "") {
-//                 try {
-//                     await this.CUR_RUNTIME.emit_gcode("G28.3 " + updtMachineLoc);
-//                 //    await config.driver.setManyWrapper(setVA_G2);
-//                 //    log.debug("##-> FINISHED AWAIT CONFIG - UPPER");
-//                     // await this.driver.requestStatusReport();
-//                     if (callback) {
-//                         // kludge to deal with calls coming from manual driver
-//                         //log.debug("##-> CALLBACK at return from MACHINELOC");
-//                         //callback(offsets.call(this, args, callback));
-//                         callback(log.debug("##-> CALLBACK return from MACHINELOC"));
-//                     }
-//                 } catch (error) {
-//                     callback(error);
-//                 }
-//             }
 
 exports.offsets = offsets;
 exports.machineLoc = machineLoc;

--- a/runtime/opensbp/commands/setting.js
+++ b/runtime/opensbp/commands/setting.js
@@ -52,7 +52,7 @@ exports.SR = function (args, callback) {
     callback();
 };
 
-// Set (restore) table (machine) base coordinates
+// Set (restore) table (machine) base coordinates by zeroing G55s
 exports.ST = function (args, callback) {
     this.machine.driver.get(
         "mpo",

--- a/runtime/opensbp/commands/setting.js
+++ b/runtime/opensbp/commands/setting.js
@@ -10,6 +10,7 @@ exports.SA = function (args, callback) {
     callback();
 };
 
+// Set Active coordinate system (not erasing either)
 exports.SC = function (args, callback) {
     try {
         switch (args[0]) {
@@ -39,6 +40,7 @@ exports.SC = function (args, callback) {
     callback();
 };
 
+// Set/Open Manual Keypay (for calling up in files)
 exports.SK = function (args, callback) {
     this.manualEnter(args[0], callback);
 };
@@ -50,7 +52,7 @@ exports.SR = function (args, callback) {
     callback();
 };
 
-// Set to table base coordinates
+// Set (restore) table (machine) base coordinates
 exports.ST = function (args, callback) {
     this.machine.driver.get(
         "mpo",
@@ -82,6 +84,7 @@ exports.ST = function (args, callback) {
     );
 };
 
+// Set an Output On or Off (note M-codes only for output 1)
 exports.SO = function (args) {
     var outnum = parseInt(args[0]);
     var state = parseInt(args[1]);
@@ -102,6 +105,7 @@ exports.SO = function (args) {
     }
 };
 
+// Output a PWM Signal *not implemented in FabMo ???
 exports.SP = function (args) {
     var outnum = parseInt(args[0]);
     var state = parseFloat(args[1]);
@@ -117,6 +121,7 @@ exports.SP = function (args) {
     }
 };
 
+// Set Units
 exports.SU = function (args) {
     var units = ((args[0] || "in") + "").toLowerCase();
 
@@ -141,6 +146,7 @@ exports.SU = function (args) {
     }
 };
 
+// Save driver settings to settings files  *Utility ???
 exports.SV = function (args, callback) {
     this._saveDriverSettings(
         // eslint-disable-next-line no-unused-vars

--- a/runtime/opensbp/commands/value.js
+++ b/runtime/opensbp/commands/value.js
@@ -2,6 +2,7 @@ var log = require("../../../log").logger("sbp");
 var config = require("../../../config");
 
 const { offsets } = require("./location");
+const { machineLoc } = require("./location");
 
 /* VALUES */
 
@@ -19,119 +20,123 @@ exports.VA = function (args, callback) {
     //   g55 offsets will persist.
     //
 
-    this.machine.driver.get(
-        "mpo",
-        async function (err, MPO) {
-            var setVA_G2 = {};
-            var unitConv = 1;
-            var updtG55axes = "";
+    // this.machine.driver.get(
+    //     "mpo",
+    //     async function (err, MPO) {
+    //         var setVA_G2 = {};
+    //         var unitConv = 1;
+    //         var updtG55axes = "";
 
-            const axes = [];
+    //         const axes = [];
 
-            if (this.machine.driver.status.unit === "in") {
-                // inches
-                unitConv = 0.039370079;
-            }
-            // Process Upper Register for Setting Machine Location
-            if (args[6] !== undefined) {
-                //X Base Coordinate
-                this.emit_gcode("G28.3 X" + args[6]);
-                MPO.x = args[6] / unitConv;
-            }
-            if (args[7] !== undefined) {
-                //Y Base Coordinate
-                this.emit_gcode("G28.3 Y" + args[7]);
-                MPO.y = args[7] / unitConv;
-            }
-            if (args[8] !== undefined) {
-                //Z Base Coordinate
-                this.emit_gcode("G28.3 Z" + args[8]);
-                MPO.z = args[8] / unitConv;
-            }
-            if (args[9] !== undefined) {
-                //A Base Coordinate
-                this.emit_gcode("G28.3 A" + args[9]);
-                MPO.a = args[9]; // / unitConv; // No unit conversion for rotary
-            }
-            if (args[10] !== undefined) {
-                //B Base Coordinate
-                this.emit_gcode("G28.3 B" + args[10]);
-                MPO.b = args[10]; // / unitConv; // No unit conversion for rotary
-            }
-            if (args[11] !== undefined) {
-                //C Base Coordinate
-                this.emit_gcode("G28.3 C" + args[11]);
-                MPO.c = args[11]; // / unitConv; // No unit conversion for rotary
-            }
-            //Process Lower Register for Required G55 Offset
-            if (args[0] !== undefined) {
-                // //X location
-                axes[0] = args[0];
-                offsets.call(this, axes, callback);
+    //         if (this.machine.driver.status.unit === "in") {
+    //             // inches
+    //             unitConv = 0.039370079;
+    //         }
 
-                // setVA_G2.g55x = Number((MPO.x * unitConv - args[0]).toFixed(5));
-                // log.debug(
-                //     "    g55X" +
-                //         JSON.stringify(setVA_G2.g55x) +
-                //         "  MPO.x = " +
-                //         MPO.x +
-                //         " args[0] = " +
-                //         args[0]
-                // );
-                // updtG55axes += "X" + setVA_G2.g55x + " ";    // start building axis request for G10 call
-                // this.cmd_posx = this.posx = args[0];
-            }
-            if (args[1] !== undefined) {
-                //Y location
-                setVA_G2.g55y = Number((MPO.y * unitConv - args[1]).toFixed(5));
-                updtG55axes += "Y" + setVA_G2.g55y + " ";
-                this.cmd_posy = this.posy = args[1];
-            }
-            if (args[2] !== undefined) {
-                //Z location
-                setVA_G2.g55z = Number((MPO.z * unitConv - args[2]).toFixed(5));
-                updtG55axes += "Z" + setVA_G2.g55z + " ";
-                this.cmd_posz = this.posz = args[2];
-            }
-            if (args[3] !== undefined) {
-                //A location
-                setVA_G2.g55a = Number(
-                    (MPO.a * 1.0 /*unitConv*/ - args[3]).toFixed(5)
-                );
-                updtG55axes += "A" + setVA_G2.g55a + " ";
-                this.cmd_posa = this.posa = args[3];
-            }
-            if (args[4] !== undefined) {
-                //B location
-                setVA_G2.g55b = Number(
-                    (MPO.b * 1.0 /*unitConv*/ - args[4]).toFixed(5)
-                );
-                updtG55axes += "B" + setVA_G2.g55b + " ";
-                this.cmd_posb = this.posb = args[4];
-            }
-            if (args[5] !== undefined) {
-                //C location
-                setVA_G2.g55c = Number(
-                    (MPO.c * 1.0 /*unitConv*/ - args[5]).toFixed(5)
-                );
-                updtG55axes += "C" + setVA_G2.g55c + " ";
-                this.cmd_posc = this.posc = args[5];
-            }
+    // Process Upper Register for Setting Machine Location
 
-            if (updtG55axes != "") {
-                // Make G10 update request if values present
-                log.debug("G10 L2 P2 " + updtG55axes);
-                this.emit_gcode("G10 L2 P2 " + updtG55axes);
-            }
+    if (args[6] !== undefined) {
+        //X Base Coordinate
+        machineLoc.call(this, args, callback);
+        //    this.emit_gcode("G28.3 X" + args[6]);
+        //    MPO.x = args[6] / unitConv;
+    }
 
-            try {
-                await config.driver.setManyWrapper(setVA_G2);
-                callback();
-            } catch (error) {
-                callback(error);
-            }
-        }.bind(this)
-    );
+    // if (args[7] !== undefined) {
+    //     //Y Base Coordinate
+    //     this.emit_gcode("G28.3 Y" + args[7]);
+    //     MPO.y = args[7] / unitConv;
+    // }
+    // if (args[8] !== undefined) {
+    //     //Z Base Coordinate
+    //     this.emit_gcode("G28.3 Z" + args[8]);
+    //     MPO.z = args[8] / unitConv;
+    // }
+    // if (args[9] !== undefined) {
+    //     //A Base Coordinate
+    //     this.emit_gcode("G28.3 A" + args[9]);
+    //     MPO.a = args[9]; // / unitConv; // No unit conversion for rotary
+    // }
+    // if (args[10] !== undefined) {
+    //     //B Base Coordinate
+    //     this.emit_gcode("G28.3 B" + args[10]);
+    //     MPO.b = args[10]; // / unitConv; // No unit conversion for rotary
+    // }
+    // if (args[11] !== undefined) {
+    //     //C Base Coordinate
+    //     this.emit_gcode("G28.3 C" + args[11]);
+    //     MPO.c = args[11]; // / unitConv; // No unit conversion for rotary
+    // }
+    //Process Lower Register for Required G55 Offset
+    if (args[0] !== undefined) {
+        // //X location
+        //    axes[0] = args[0];
+        offsets.call(this, args, callback);
+
+        // setVA_G2.g55x = Number((MPO.x * unitConv - args[0]).toFixed(5));
+        // log.debug(
+        //     "    g55X" +
+        //         JSON.stringify(setVA_G2.g55x) +
+        //         "  MPO.x = " +
+        //         MPO.x +
+        //         " args[0] = " +
+        //         args[0]
+        // );
+        // updtG55axes += "X" + setVA_G2.g55x + " ";    // start building axis request for G10 call
+        // this.cmd_posx = this.posx = args[0];
+    }
+    // if (args[1] !== undefined) {
+    //     //Y location
+    //     setVA_G2.g55y = Number((MPO.y * unitConv - args[1]).toFixed(5));
+    //     updtG55axes += "Y" + setVA_G2.g55y + " ";
+    //     this.cmd_posy = this.posy = args[1];
+    // }
+    // if (args[2] !== undefined) {
+    //     //Z location
+    //     setVA_G2.g55z = Number((MPO.z * unitConv - args[2]).toFixed(5));
+    //     updtG55axes += "Z" + setVA_G2.g55z + " ";
+    //     this.cmd_posz = this.posz = args[2];
+    // }
+    // if (args[3] !== undefined) {
+    //     //A location
+    //     setVA_G2.g55a = Number(
+    //         (MPO.a * 1.0 /*unitConv*/ - args[3]).toFixed(5)
+    //     );
+    //     updtG55axes += "A" + setVA_G2.g55a + " ";
+    //     this.cmd_posa = this.posa = args[3];
+    // }
+    // if (args[4] !== undefined) {
+    //     //B location
+    //     setVA_G2.g55b = Number(
+    //         (MPO.b * 1.0 /*unitConv*/ - args[4]).toFixed(5)
+    //     );
+    //     updtG55axes += "B" + setVA_G2.g55b + " ";
+    //     this.cmd_posb = this.posb = args[4];
+    // }
+    // if (args[5] !== undefined) {
+    //     //C location
+    //     setVA_G2.g55c = Number(
+    //         (MPO.c * 1.0 /*unitConv*/ - args[5]).toFixed(5)
+    //     );
+    //     updtG55axes += "C" + setVA_G2.g55c + " ";
+    //     this.cmd_posc = this.posc = args[5];
+    // }
+
+    // if (updtG55axes != "") {
+    //     // Make G10 update request if values present
+    //     log.debug("G10 L2 P2 " + updtG55axes);
+    //     this.emit_gcode("G10 L2 P2 " + updtG55axes);
+    // }
+
+    //         try {
+    //             await config.driver.setManyWrapper(setVA_G2);
+    //             callback();
+    //         } catch (error) {
+    //             callback(error);
+    //         }
+    //     }.bind(this)
+    // );
 };
 
 exports.VC = function (args, callback) {

--- a/runtime/opensbp/commands/value.js
+++ b/runtime/opensbp/commands/value.js
@@ -7,7 +7,6 @@ const { offsets } = require("./location");
 /* VALUES */
 
 exports.VA = function (args, callback) {
-    log.debug("VA Command: " + args);
     // VA Command is complex because in gcode terms it is two commands: the lower "args" register of 6 parameters emits a
     //   ... G10 L2 P2 (setting g55 offsets) and the upper register emits a G28.3 (setting axes to absolute locations,
     //   ... optionally zero). If it has changes, the upper register is executed first; then changes to the g55 values
@@ -15,97 +14,8 @@ exports.VA = function (args, callback) {
     // New values included in the command replace existing G55 values.
     // Note that the number entered into the offset register is not the new g55 value itself, but is the new desired
     //   ... location, from which a new g55 is computed.
-
-    // // Process Upper Register for Setting Machine Location (needs to be done before offsets if there are any)
-    // const subArgs = args.slice(6, 11); // Check to see if there are any in top of array
-    // if (subArgs.some((val) => val !== undefined)) {
-    //     log.debug("Machine Base Changes being Processed First!");
-    //     machineLoc.call(this, args, callback);
-    // } else {
-    //     log.debug("--> No Machine Base Value Changes in this VA");
-    // }
-    //    log.debug("####-> Calling machineLoc for VA");
-    //    machineLoc.call(this, args, callback);
-    log.debug("####-> Calling offsets for VA");
+    log.debug("Calling offsets for VA");
     offsets.call(this, args, callback);
-
-    // }
-    // if (axes !== undefined) {         // then pass this to the location.js functions
-    //     //X Base Coordinate
-    //     machineLoc.call(this, axes, callback);
-    //     //    this.emit_gcode("G28.3 X" + args[6]);
-    //     //    MPO.x = args[6] / unitConv;
-    // }
-
-    //Process Lower Register for Required G55 Offset (needs to follow after machine base location is reset, if reset)
-    //    if (args[0] !== undefined) {
-    // //X location
-    //    axes[0] = args[0];
-    //        offsets.call(this, args, callback);
-
-    // setVA_G2.g55x = Number((MPO.x * unitConv - args[0]).toFixed(5));
-    // log.debug(
-    //     "    g55X" +
-    //         JSON.stringify(setVA_G2.g55x) +
-    //         "  MPO.x = " +
-    //         MPO.x +
-    //         " args[0] = " +
-    //         args[0]
-    // );
-    // updtG55axes += "X" + setVA_G2.g55x + " ";    // start building axis request for G10 call
-    // this.cmd_posx = this.posx = args[0];
-    //    }
-    // if (args[1] !== undefined) {
-    //     //Y location
-    //     setVA_G2.g55y = Number((MPO.y * unitConv - args[1]).toFixed(5));
-    //     updtG55axes += "Y" + setVA_G2.g55y + " ";
-    //     this.cmd_posy = this.posy = args[1];
-    // }
-    // if (args[2] !== undefined) {
-    //     //Z location
-    //     setVA_G2.g55z = Number((MPO.z * unitConv - args[2]).toFixed(5));
-    //     updtG55axes += "Z" + setVA_G2.g55z + " ";
-    //     this.cmd_posz = this.posz = args[2];
-    // }
-    // if (args[3] !== undefined) {
-    //     //A location
-    //     setVA_G2.g55a = Number(
-    //         (MPO.a * 1.0 /*unitConv*/ - args[3]).toFixed(5)
-    //     );
-    //     updtG55axes += "A" + setVA_G2.g55a + " ";
-    //     this.cmd_posa = this.posa = args[3];
-    // }
-    // if (args[4] !== undefined) {
-    //     //B location
-    //     setVA_G2.g55b = Number(
-    //         (MPO.b * 1.0 /*unitConv*/ - args[4]).toFixed(5)
-    //     );
-    //     updtG55axes += "B" + setVA_G2.g55b + " ";
-    //     this.cmd_posb = this.posb = args[4];
-    // }
-    // if (args[5] !== undefined) {
-    //     //C location
-    //     setVA_G2.g55c = Number(
-    //         (MPO.c * 1.0 /*unitConv*/ - args[5]).toFixed(5)
-    //     );
-    //     updtG55axes += "C" + setVA_G2.g55c + " ";
-    //     this.cmd_posc = this.posc = args[5];
-    // }
-
-    // if (updtG55axes != "") {
-    //     // Make G10 update request if values present
-    //     log.debug("G10 L2 P2 " + updtG55axes);
-    //     this.emit_gcode("G10 L2 P2 " + updtG55axes);
-    // }
-
-    //         try {
-    //             await config.driver.setManyWrapper(setVA_G2);
-    //             callback();
-    //         } catch (error) {
-    //             callback(error);
-    //         }
-    //     }.bind(this)
-    // );
 };
 
 exports.VC = function (args, callback) {

--- a/runtime/opensbp/commands/value.js
+++ b/runtime/opensbp/commands/value.js
@@ -1,8 +1,8 @@
 var log = require("../../../log").logger("sbp");
 var config = require("../../../config");
 
-//const { offsets } = require("./location");
-const { machineLoc } = require("./location");
+const { offsets } = require("./location");
+//const { machineLoc } = require("./location");
 
 /* VALUES */
 
@@ -16,14 +16,19 @@ exports.VA = function (args, callback) {
     // Note that the number entered into the offset register is not the new g55 value itself, but is the new desired
     //   ... location, from which a new g55 is computed.
 
-    // Process Upper Register for Setting Machine Location (needs to be done before offsets if there are any)
-    const subArgs = args.slice(6, 11); // Check to see if there are any in top of array
-    if (subArgs.some((val) => val !== undefined)) {
-        log.debug("Machine Base Changes being Processed First!");
-        machineLoc.call(this, args, callback);
-    } else {
-        log.debug("--> No Machine Base Value Changes in this VA");
-    }
+    // // Process Upper Register for Setting Machine Location (needs to be done before offsets if there are any)
+    // const subArgs = args.slice(6, 11); // Check to see if there are any in top of array
+    // if (subArgs.some((val) => val !== undefined)) {
+    //     log.debug("Machine Base Changes being Processed First!");
+    //     machineLoc.call(this, args, callback);
+    // } else {
+    //     log.debug("--> No Machine Base Value Changes in this VA");
+    // }
+    //    log.debug("####-> Calling machineLoc for VA");
+    //    machineLoc.call(this, args, callback);
+    log.debug("####-> Calling offsets for VA");
+    offsets.call(this, args, callback);
+    //offsets(args, callback);
 
     // }
     // if (axes !== undefined) {         // then pass this to the location.js functions

--- a/runtime/opensbp/commands/value.js
+++ b/runtime/opensbp/commands/value.js
@@ -28,7 +28,6 @@ exports.VA = function (args, callback) {
     //    machineLoc.call(this, args, callback);
     log.debug("####-> Calling offsets for VA");
     offsets.call(this, args, callback);
-    //offsets(args, callback);
 
     // }
     // if (axes !== undefined) {         // then pass this to the location.js functions

--- a/runtime/opensbp/commands/zero.js
+++ b/runtime/opensbp/commands/zero.js
@@ -9,54 +9,52 @@ const { offsets } = require("./location");
 // U,V,W not yet covered!
 
 exports.ZX = function (args, callback) {
-    // x=0
-    //const axes = [];
-    //axes[0] = 0;
+    log.debug("####-> Calling Offsets for ZX");
     args = [];
     args[0] = 0;
     offsets.call(this, args, callback);
 };
 
 exports.ZY = function (args, callback) {
-    const axes = [];
-    axes[1] = 0;
-    offsets.call(this, axes, callback);
+    args = [];
+    args[1] = 0;
+    offsets.call(this, args, callback);
 };
 
 exports.ZZ = function (args, callback) {
-    //const axes = [];
-    //axes[2] = 0;
+    log.debug("####-> Calling Offsets for ZZ");
     args = [];
     args[2] = 0;
     offsets.call(this, args, callback);
 };
 
 exports.ZA = function (args, callback) {
-    const axes = [];
-    axes[3] = 0;
-    offsets.call(this, axes, callback);
+    args = [];
+    args[3] = 0;
+    offsets.call(this, args, callback);
 };
 
 exports.ZB = function (args, callback) {
-    const axes = [];
-    axes[4] = 0;
-    offsets.call(this, axes, callback);
+    args = [];
+    args[4] = 0;
+    offsets.call(this, args, callback);
 };
 
 exports.ZC = function (args, callback) {
-    const axes = [];
-    axes[5] = 0;
-    offsets.call(this, axes, callback);
+    args = [];
+    args[5] = 0;
+    offsets.call(this, args, callback);
 };
 
 exports.Z2 = function (args, callback) {
-    const axes = [];
-    axes[0] = 0;
-    axes[1] = 0;
-    offsets.call(this, axes, callback);
+    args = [];
+    args[0] = 0;
+    args[1] = 0;
+    offsets.call(this, args, callback);
 };
 
 exports.Z3 = function (args, callback) {
+    log.debug("####-> Calling Offsets for Z3");
     args = [];
     args[0] = 0;
     args[1] = 0;
@@ -65,33 +63,33 @@ exports.Z3 = function (args, callback) {
 };
 
 exports.Z4 = function (args, callback) {
-    const axes = [];
-    axes[0] = 0;
-    axes[1] = 0;
-    axes[2] = 0;
-    axes[3] = 0;
-    offsets.call(this, axes, callback);
+    args = [];
+    args[0] = 0;
+    args[1] = 0;
+    args[2] = 0;
+    args[3] = 0;
+    offsets.call(this, args, callback);
 };
 
 exports.Z5 = function (args, callback) {
-    const axes = [];
-    axes[0] = 0;
-    axes[1] = 0;
-    axes[2] = 0;
-    axes[3] = 0;
-    axes[4] = 0;
-    offsets.call(this, axes, callback);
+    args = [];
+    args[0] = 0;
+    args[1] = 0;
+    args[2] = 0;
+    args[3] = 0;
+    args[4] = 0;
+    offsets.call(this, args, callback);
 };
 
 exports.Z6 = function (args, callback) {
-    const axes = [];
-    axes[0] = 0;
-    axes[1] = 0;
-    axes[2] = 0;
-    axes[3] = 0;
-    axes[4] = 0;
-    axes[5] = 0;
-    offsets.call(this, axes, callback);
+    args = [];
+    args[0] = 0;
+    args[1] = 0;
+    args[2] = 0;
+    args[3] = 0;
+    args[4] = 0;
+    args[5] = 0;
+    offsets.call(this, args, callback);
 };
 
 // // Will need to attend to U,V,W at some point

--- a/runtime/opensbp/commands/zero.js
+++ b/runtime/opensbp/commands/zero.js
@@ -1,319 +1,246 @@
-var log = require("../../../log").logger("sbp");
+//var log = require("../../../log").logger("sbp");
 var config = require("../../../config");
+
+const { offsets } = require("./location");
 
 /* ZERO */
 
-// {"mpo":""}  return absolute machine positions fox XYZABC axes.
-// !!!!!!!!!!!! Always in mm, regardless of G20/G21 setting
+// See Notes in location.js for offsetting and zeroing commands and functions
+// U,V,W not yet covered!
 
-// {"pos":""}  return work coordinate positions fox XYZABC axes.
-//              In mm or inches depending on G20 or G21
-
-// {"g55":""}  returns the current offset to the UCS origin
-//              In mm or inches depending on G20 or G21
+const axes = []; // X=0
 
 exports.ZX = function (args, callback) {
-    this.machine.driver.get(
-        "mpox",
-        async function (err, MPO) {
-            if (err) {
-                return callback(err);
-            }
-            var zxObj = {};
-            var unitConv = 1.0;
-            if (this.machine.driver.status.unit === "in") {
-                // inches
-                unitConv = 0.039370079;
-            }
-            zxObj.g55x = Number((MPO * unitConv).toFixed(5));
-            try {
-                await config.driver.setManyWrapper(zxObj);
-                this.cmd_posx = this.posx = 0;
-                callback();
-            } catch (error) {
-                callback(error);
-            }
-        }.bind(this)
-    );
+    axes[0] = 0;
+    offsets.call(this, axes, callback);
 };
 
 exports.ZY = function (args, callback) {
-    this.machine.driver.get(
-        "mpoy",
-        async function (err, MPO) {
-            if (err) {
-                return callback(err);
-            }
-            var zyObj = {};
-            var unitConv = 1.0;
-            if (this.machine.driver.status.unit === "in") {
-                // inches
-                unitConv = 0.039370079;
-            }
-            zyObj.g55y = Number((MPO * unitConv).toFixed(5));
-            try {
-                await config.driver.setManyWrapper(zyObj);
-                this.cmd_posy = this.posy = 0;
-                callback();
-            } catch (error) {
-                callback(error);
-            }
-        }.bind(this)
-    );
+    axes[1] = 0;
+    offsets.call(this, axes, callback);
 };
 
 exports.ZZ = function (args, callback) {
-    this.machine.driver.get(
-        "mpoz",
-        async function (err, MPO) {
-            var zzObj = {};
-            var unitConv = 1.0;
-            if (this.machine.driver.status.unit === "in") {
-                // inches
-                unitConv = 0.039370079;
-            }
-            zzObj.g55z = Number((MPO * unitConv).toFixed(5));
-            try {
-                await config.driver.setManyWrapper(zzObj);
-                this.cmd_posz = this.posz = 0;
-                callback();
-            } catch (error) {
-                callback(error);
-            }
-        }.bind(this)
-    );
+    axes[2] = 0;
+    offsets.call(this, axes, callback);
 };
 
 exports.ZA = function (args, callback) {
-    this.machine.driver.get(
-        "mpoa",
-        async function (err, MPO) {
-            if (err) {
-                return callback(err);
-            }
-            var zaObj = {};
-            var unitConv = 1.0;
-            // TODO: ?
-            /*??????????????????????????????????????????????????????????
-		              How is unit conversion handled
-		              if the A is a linear axis?
-		????????????????????????????????????????????????????????????*/
-            // if ( this.machine.driver.status.unit === 'in' ) {  // inches
-            // 	unitConv = 0.039370079;
-            // }
-            zaObj.g55a = Number((MPO * unitConv).toFixed(5));
-            try {
-                await config.driver.setManyWrapper(zaObj);
-                this.cmd_posa = this.posa = 0;
-                callback();
-            } catch (error) {
-                callback(error);
-            }
-        }.bind(this)
-    );
+    axes[3] = 0;
+    offsets.call(this, axes, callback);
 };
 
 exports.ZB = function (args, callback) {
-    this.machine.driver.get(
-        "mpob",
-        async function (err, MPO) {
-            if (err) {
-                return callback(err);
-            }
-            var zbObj = {};
-            zbObj.g55b = Number(MPO.toFixed(5));
-            try {
-                await config.driver.setManyWrapper(zbObj);
-                this.cmd_posb = this.posb = 0;
-                callback();
-            } catch (error) {
-                callback(error);
-            }
-        }.bind(this)
-    );
+    axes[4] = 0;
+    offsets.call(this, axes, callback);
 };
 
 exports.ZC = function (args, callback) {
-    this.machine.driver.get(
-        "mpoc",
-        async function (err, MPO) {
-            if (err) {
-                return callback(err);
-            }
-            var zcObj = {};
-            zcObj.g55c = Number(MPO.toFixed(5));
-            try {
-                await config.driver.setManyWrapper(zcObj);
-                this.cmd_posc = this.posc = 0;
-                callback();
-            } catch (error) {
-                callback(error);
-            }
-        }.bind(this)
-    );
+    axes[5] = 0;
+    offsets.call(this, axes, callback);
 };
 
 exports.Z2 = function (args, callback) {
-    this.machine.driver.get(
-        "mpo",
-        async function (err, MPO) {
-            if (err) {
-                return callback(err);
-            }
-            var z2Obj = {};
-            var unitConv = 1.0;
-            if (this.machine.driver.status.unit === "in") {
-                // inches
-                unitConv = 0.039370079;
-            }
-            z2Obj.g55x = Number((MPO.x * unitConv).toFixed(5));
-            z2Obj.g55y = Number((MPO.y * unitConv).toFixed(5));
-            try {
-                await config.driver.setManyWrapper(z2Obj);
-                this.cmd_posx = this.posx = 0;
-                this.cmd_posy = this.posy = 0;
-                callback();
-            } catch (error) {
-                callback(error);
-            }
-        }.bind(this)
-    );
+    axes[0] = 0;
+    axes[1] = 0;
+    offsets.call(this, axes, callback);
 };
 
 exports.Z3 = function (args, callback) {
-    this.machine.driver.get(
-        "mpo",
-        async function (err, MPO) {
-            if (err) {
-                return callback(err);
-            }
-            var z3Obj = {};
-            log.debug(JSON.stringify(MPO));
-            var unitConv = 1.0;
-            if (this.machine.driver.status.unit === "in") {
-                // inches
-                unitConv = 0.039370079;
-            }
-            z3Obj.g55x = Number((MPO.x * unitConv).toFixed(5));
-            z3Obj.g55y = Number((MPO.y * unitConv).toFixed(5));
-            z3Obj.g55z = Number((MPO.z * unitConv).toFixed(5));
-            log.debug(JSON.stringify(z3Obj));
-            try {
-                await config.driver.setManyWrapper(z3Obj);
-                this.cmd_posx = this.posx = 0.0;
-                this.cmd_posy = this.posy = 0.0;
-                this.cmd_posz = this.posz = 0.0;
-                callback();
-            } catch (error) {
-                callback(error);
-            }
-        }.bind(this)
-    );
+    axes[0] = 0;
+    axes[1] = 0;
+    axes[2] = 0;
+    offsets.call(this, axes, callback);
 };
 
 exports.Z4 = function (args, callback) {
-    this.machine.driver.get(
-        "mpo",
-        async function (err, MPO) {
-            if (err) {
-                return callback(err);
-            }
-            var z4Obj = {};
-            var unitConv = 1.0;
-            if (this.machine.driver.status.unit === "in") {
-                // inches
-                unitConv = 0.039370079;
-            }
-            // Unit conversion
-            z4Obj.g55x = Number((MPO.x * unitConv).toFixed(5));
-            z4Obj.g55y = Number((MPO.y * unitConv).toFixed(5));
-            z4Obj.g55z = Number((MPO.z * unitConv).toFixed(5));
-            // No unit conversion (rotary)
-            z4Obj.g55a = Number(MPO.a.toFixed(5));
-            try {
-                await config.driver.setManyWrapper(z4Obj);
-                this.cmd_posx = this.posx = 0.0;
-                this.cmd_posy = this.posy = 0.0;
-                this.cmd_posz = this.posz = 0.0;
-                this.cmd_posa = this.posa = 0.0;
-                callback();
-            } catch (error) {
-                callback(error);
-            }
-        }.bind(this)
-    );
+    axes[0] = 0;
+    axes[1] = 0;
+    axes[2] = 0;
+    axes[3] = 0;
+    offsets.call(this, axes, callback);
 };
 
 exports.Z5 = function (args, callback) {
-    this.machine.driver.get(
-        "mpo",
-        async function (err, MPO) {
-            if (err) {
-                return callback(err);
-            }
-            var z5Obj = {};
-            var unitConv = 1.0;
-            if (this.machine.driver.status.unit === "in") {
-                // inches
-                unitConv = 0.039370079;
-            }
-            // Unit conversion
-            z5Obj.g55x = Number((MPO.x * unitConv).toFixed(5));
-            z5Obj.g55y = Number((MPO.y * unitConv).toFixed(5));
-            z5Obj.g55z = Number((MPO.z * unitConv).toFixed(5));
-            // No unit conversion (rotary)
-            z5Obj.g55a = Number(MPO.a.toFixed(5));
-            z5Obj.g55b = Number(MPO.b.toFixed(5));
-            try {
-                await config.driver.setManyWrapper(z5Obj);
-                this.cmd_posx = this.posx = 0.0;
-                this.cmd_posy = this.posy = 0.0;
-                this.cmd_posz = this.posz = 0.0;
-                this.cmd_posa = this.posa = 0.0;
-                this.cmd_posb = this.posb = 0.0;
-                callback();
-            } catch (error) {
-                callback(error);
-            }
-        }.bind(this)
-    );
+    axes[0] = 0;
+    axes[1] = 0;
+    axes[2] = 0;
+    axes[3] = 0;
+    axes[4] = 0;
+    offsets.call(this, axes, callback);
 };
 
 exports.Z6 = function (args, callback) {
-    this.machine.driver.get(
-        "mpo",
-        async function (err, MPO) {
-            if (err) {
-                return callback(err);
-            }
-            var z6Obj = {};
-            var unitConv = 1.0;
-            if (this.machine.driver.status.unit === "in") {
-                // inches
-                unitConv = 0.039370079;
-            }
-            z6Obj.g55x = Number((MPO.x * unitConv).toFixed(5));
-            z6Obj.g55y = Number((MPO.y * unitConv).toFixed(5));
-            z6Obj.g55z = Number((MPO.z * unitConv).toFixed(5));
-            // No unit conversion
-            z6Obj.g55a = Number(MPO.a.toFixed(5));
-            z6Obj.g55b = Number(MPO.b.toFixed(5));
-            z6Obj.g55c = Number(MPO.c.toFixed(5));
-            try {
-                await config.driver.setManyWrapper(z6Obj);
-                this.cmd_posx = this.posx = 0.0;
-                this.cmd_posy = this.posy = 0.0;
-                this.cmd_posz = this.posz = 0.0;
-                this.cmd_posa = this.posa = 0.0;
-                this.cmd_posb = this.posb = 0.0;
-                this.cmd_posc = this.posc = 0.0;
-                callback();
-            } catch (error) {
-                callback(error);
-            }
-        }.bind(this)
-    );
+    axes[0] = 0;
+    axes[1] = 0;
+    axes[2] = 0;
+    axes[3] = 0;
+    axes[4] = 0;
+    axes[5] = 0;
+    offsets.call(this, axes, callback);
 };
+
+// exports.Z2 = function (args, callback) {
+//     this.machine.driver.get(
+//         "mpo",
+//         async function (err, MPO) {
+//             if (err) {
+//                 return callback(err);
+//             }
+//             var z2Obj = {};
+//             var unitConv = 1.0;
+//             if (this.machine.driver.status.unit === "in") {
+//                 // inches
+//                 unitConv = 0.039370079;
+//             }
+//             z2Obj.g55x = Number((MPO.x * unitConv).toFixed(5));
+//             z2Obj.g55y = Number((MPO.y * unitConv).toFixed(5));
+//             try {
+//                 await config.driver.setManyWrapper(z2Obj);
+//                 this.cmd_posx = this.posx = 0;
+//                 this.cmd_posy = this.posy = 0;
+//                 callback();
+//             } catch (error) {
+//                 callback(error);
+//             }
+//         }.bind(this)
+//     );
+// };
+
+// exports.Z3 = function (args, callback) {
+//     this.machine.driver.get(
+//         "mpo",
+//         async function (err, MPO) {
+//             if (err) {
+//                 return callback(err);
+//             }
+//             var z3Obj = {};
+//             log.debug(JSON.stringify(MPO));
+//             var unitConv = 1.0;
+//             if (this.machine.driver.status.unit === "in") {
+//                 // inches
+//                 unitConv = 0.039370079;
+//             }
+//             z3Obj.g55x = Number((MPO.x * unitConv).toFixed(5));
+//             z3Obj.g55y = Number((MPO.y * unitConv).toFixed(5));
+//             z3Obj.g55z = Number((MPO.z * unitConv).toFixed(5));
+//             log.debug(JSON.stringify(z3Obj));
+//             try {
+//                 await config.driver.setManyWrapper(z3Obj);
+//                 this.cmd_posx = this.posx = 0.0;
+//                 this.cmd_posy = this.posy = 0.0;
+//                 this.cmd_posz = this.posz = 0.0;
+//                 callback();
+//             } catch (error) {
+//                 callback(error);
+//             }
+//         }.bind(this)
+//     );
+// };
+
+// exports.Z4 = function (args, callback) {
+//     this.machine.driver.get(
+//         "mpo",
+//         async function (err, MPO) {
+//             if (err) {
+//                 return callback(err);
+//             }
+//             var z4Obj = {};
+//             var unitConv = 1.0;
+//             if (this.machine.driver.status.unit === "in") {
+//                 // inches
+//                 unitConv = 0.039370079;
+//             }
+//             // Unit conversion
+//             z4Obj.g55x = Number((MPO.x * unitConv).toFixed(5));
+//             z4Obj.g55y = Number((MPO.y * unitConv).toFixed(5));
+//             z4Obj.g55z = Number((MPO.z * unitConv).toFixed(5));
+//             // No unit conversion (rotary)
+//             z4Obj.g55a = Number(MPO.a.toFixed(5));
+//             try {
+//                 await config.driver.setManyWrapper(z4Obj);
+//                 this.cmd_posx = this.posx = 0.0;
+//                 this.cmd_posy = this.posy = 0.0;
+//                 this.cmd_posz = this.posz = 0.0;
+//                 this.cmd_posa = this.posa = 0.0;
+//                 callback();
+//             } catch (error) {
+//                 callback(error);
+//             }
+//         }.bind(this)
+//     );
+// };
+
+// exports.Z5 = function (args, callback) {
+//     this.machine.driver.get(
+//         "mpo",
+//         async function (err, MPO) {
+//             if (err) {
+//                 return callback(err);
+//             }
+//             var z5Obj = {};
+//             var unitConv = 1.0;
+//             if (this.machine.driver.status.unit === "in") {
+//                 // inches
+//                 unitConv = 0.039370079;
+//             }
+//             // Unit conversion
+//             z5Obj.g55x = Number((MPO.x * unitConv).toFixed(5));
+//             z5Obj.g55y = Number((MPO.y * unitConv).toFixed(5));
+//             z5Obj.g55z = Number((MPO.z * unitConv).toFixed(5));
+//             // No unit conversion (rotary)
+//             z5Obj.g55a = Number(MPO.a.toFixed(5));
+//             z5Obj.g55b = Number(MPO.b.toFixed(5));
+//             try {
+//                 await config.driver.setManyWrapper(z5Obj);
+//                 this.cmd_posx = this.posx = 0.0;
+//                 this.cmd_posy = this.posy = 0.0;
+//                 this.cmd_posz = this.posz = 0.0;
+//                 this.cmd_posa = this.posa = 0.0;
+//                 this.cmd_posb = this.posb = 0.0;
+//                 callback();
+//             } catch (error) {
+//                 callback(error);
+//             }
+//         }.bind(this)
+//     );
+// };
+
+// exports.Z6 = function (args, callback) {
+//     this.machine.driver.get(
+//         "mpo",
+//         async function (err, MPO) {
+//             if (err) {
+//                 return callback(err);
+//             }
+//             var z6Obj = {};
+//             var unitConv = 1.0;
+//             if (this.machine.driver.status.unit === "in") {
+//                 // inches
+//                 unitConv = 0.039370079;
+//             }
+//             z6Obj.g55x = Number((MPO.x * unitConv).toFixed(5));
+//             z6Obj.g55y = Number((MPO.y * unitConv).toFixed(5));
+//             z6Obj.g55z = Number((MPO.z * unitConv).toFixed(5));
+//             // No unit conversion
+//             z6Obj.g55a = Number(MPO.a.toFixed(5));
+//             z6Obj.g55b = Number(MPO.b.toFixed(5));
+//             z6Obj.g55c = Number(MPO.c.toFixed(5));
+//             try {
+//                 await config.driver.setManyWrapper(z6Obj);
+//                 this.cmd_posx = this.posx = 0.0;
+//                 this.cmd_posy = this.posy = 0.0;
+//                 this.cmd_posz = this.posz = 0.0;
+//                 this.cmd_posa = this.posa = 0.0;
+//                 this.cmd_posb = this.posb = 0.0;
+//                 this.cmd_posc = this.posc = 0.0;
+//                 callback();
+//             } catch (error) {
+//                 callback(error);
+//             }
+//         }.bind(this)
+//     );
+// };
 
 ////## update ZT to cover all axes 2/4/22, will still need to attend to U,V,W
 exports.ZT = async function (args, callback) {

--- a/runtime/opensbp/commands/zero.js
+++ b/runtime/opensbp/commands/zero.js
@@ -8,13 +8,13 @@ const { offsets } = require("./location");
 // See Notes in location.js for offsetting and zeroing commands and functions
 // U,V,W not yet covered!
 
-//const axes = []; // X=0
-
 exports.ZX = function (args, callback) {
     // x=0
-    const axes = [];
-    axes[0] = 0;
-    offsets.call(this, axes, callback);
+    //const axes = [];
+    //axes[0] = 0;
+    args = [];
+    args[0] = 0;
+    offsets.call(this, args, callback);
 };
 
 exports.ZY = function (args, callback) {
@@ -55,11 +55,11 @@ exports.Z2 = function (args, callback) {
 };
 
 exports.Z3 = function (args, callback) {
-    const axes = [];
-    axes[0] = 0;
-    axes[1] = 0;
-    axes[2] = 0;
-    offsets.call(this, axes, callback);
+    args = [];
+    args[0] = 0;
+    args[1] = 0;
+    args[2] = 0;
+    offsets.call(this, args, callback);
 };
 
 exports.Z4 = function (args, callback) {

--- a/runtime/opensbp/commands/zero.js
+++ b/runtime/opensbp/commands/zero.js
@@ -8,45 +8,54 @@ const { offsets } = require("./location");
 // See Notes in location.js for offsetting and zeroing commands and functions
 // U,V,W not yet covered!
 
-const axes = []; // X=0
+//const axes = []; // X=0
 
 exports.ZX = function (args, callback) {
+    // x=0
+    const axes = [];
     axes[0] = 0;
     offsets.call(this, axes, callback);
 };
 
 exports.ZY = function (args, callback) {
+    const axes = [];
     axes[1] = 0;
     offsets.call(this, axes, callback);
 };
 
 exports.ZZ = function (args, callback) {
+    const axes = [];
     axes[2] = 0;
     offsets.call(this, axes, callback);
 };
 
 exports.ZA = function (args, callback) {
+    const axes = [];
     axes[3] = 0;
     offsets.call(this, axes, callback);
 };
 
 exports.ZB = function (args, callback) {
+    const axes = [];
     axes[4] = 0;
     offsets.call(this, axes, callback);
 };
 
 exports.ZC = function (args, callback) {
+    const axes = [];
     axes[5] = 0;
     offsets.call(this, axes, callback);
 };
 
 exports.Z2 = function (args, callback) {
+    const axes = [];
     axes[0] = 0;
     axes[1] = 0;
     offsets.call(this, axes, callback);
 };
 
 exports.Z3 = function (args, callback) {
+    const axes = [];
     axes[0] = 0;
     axes[1] = 0;
     axes[2] = 0;
@@ -54,6 +63,7 @@ exports.Z3 = function (args, callback) {
 };
 
 exports.Z4 = function (args, callback) {
+    const axes = [];
     axes[0] = 0;
     axes[1] = 0;
     axes[2] = 0;
@@ -62,6 +72,7 @@ exports.Z4 = function (args, callback) {
 };
 
 exports.Z5 = function (args, callback) {
+    const axes = [];
     axes[0] = 0;
     axes[1] = 0;
     axes[2] = 0;
@@ -71,6 +82,7 @@ exports.Z5 = function (args, callback) {
 };
 
 exports.Z6 = function (args, callback) {
+    const axes = [];
     axes[0] = 0;
     axes[1] = 0;
     axes[2] = 0;
@@ -80,169 +92,7 @@ exports.Z6 = function (args, callback) {
     offsets.call(this, axes, callback);
 };
 
-// exports.Z2 = function (args, callback) {
-//     this.machine.driver.get(
-//         "mpo",
-//         async function (err, MPO) {
-//             if (err) {
-//                 return callback(err);
-//             }
-//             var z2Obj = {};
-//             var unitConv = 1.0;
-//             if (this.machine.driver.status.unit === "in") {
-//                 // inches
-//                 unitConv = 0.039370079;
-//             }
-//             z2Obj.g55x = Number((MPO.x * unitConv).toFixed(5));
-//             z2Obj.g55y = Number((MPO.y * unitConv).toFixed(5));
-//             try {
-//                 await config.driver.setManyWrapper(z2Obj);
-//                 this.cmd_posx = this.posx = 0;
-//                 this.cmd_posy = this.posy = 0;
-//                 callback();
-//             } catch (error) {
-//                 callback(error);
-//             }
-//         }.bind(this)
-//     );
-// };
-
-// exports.Z3 = function (args, callback) {
-//     this.machine.driver.get(
-//         "mpo",
-//         async function (err, MPO) {
-//             if (err) {
-//                 return callback(err);
-//             }
-//             var z3Obj = {};
-//             log.debug(JSON.stringify(MPO));
-//             var unitConv = 1.0;
-//             if (this.machine.driver.status.unit === "in") {
-//                 // inches
-//                 unitConv = 0.039370079;
-//             }
-//             z3Obj.g55x = Number((MPO.x * unitConv).toFixed(5));
-//             z3Obj.g55y = Number((MPO.y * unitConv).toFixed(5));
-//             z3Obj.g55z = Number((MPO.z * unitConv).toFixed(5));
-//             log.debug(JSON.stringify(z3Obj));
-//             try {
-//                 await config.driver.setManyWrapper(z3Obj);
-//                 this.cmd_posx = this.posx = 0.0;
-//                 this.cmd_posy = this.posy = 0.0;
-//                 this.cmd_posz = this.posz = 0.0;
-//                 callback();
-//             } catch (error) {
-//                 callback(error);
-//             }
-//         }.bind(this)
-//     );
-// };
-
-// exports.Z4 = function (args, callback) {
-//     this.machine.driver.get(
-//         "mpo",
-//         async function (err, MPO) {
-//             if (err) {
-//                 return callback(err);
-//             }
-//             var z4Obj = {};
-//             var unitConv = 1.0;
-//             if (this.machine.driver.status.unit === "in") {
-//                 // inches
-//                 unitConv = 0.039370079;
-//             }
-//             // Unit conversion
-//             z4Obj.g55x = Number((MPO.x * unitConv).toFixed(5));
-//             z4Obj.g55y = Number((MPO.y * unitConv).toFixed(5));
-//             z4Obj.g55z = Number((MPO.z * unitConv).toFixed(5));
-//             // No unit conversion (rotary)
-//             z4Obj.g55a = Number(MPO.a.toFixed(5));
-//             try {
-//                 await config.driver.setManyWrapper(z4Obj);
-//                 this.cmd_posx = this.posx = 0.0;
-//                 this.cmd_posy = this.posy = 0.0;
-//                 this.cmd_posz = this.posz = 0.0;
-//                 this.cmd_posa = this.posa = 0.0;
-//                 callback();
-//             } catch (error) {
-//                 callback(error);
-//             }
-//         }.bind(this)
-//     );
-// };
-
-// exports.Z5 = function (args, callback) {
-//     this.machine.driver.get(
-//         "mpo",
-//         async function (err, MPO) {
-//             if (err) {
-//                 return callback(err);
-//             }
-//             var z5Obj = {};
-//             var unitConv = 1.0;
-//             if (this.machine.driver.status.unit === "in") {
-//                 // inches
-//                 unitConv = 0.039370079;
-//             }
-//             // Unit conversion
-//             z5Obj.g55x = Number((MPO.x * unitConv).toFixed(5));
-//             z5Obj.g55y = Number((MPO.y * unitConv).toFixed(5));
-//             z5Obj.g55z = Number((MPO.z * unitConv).toFixed(5));
-//             // No unit conversion (rotary)
-//             z5Obj.g55a = Number(MPO.a.toFixed(5));
-//             z5Obj.g55b = Number(MPO.b.toFixed(5));
-//             try {
-//                 await config.driver.setManyWrapper(z5Obj);
-//                 this.cmd_posx = this.posx = 0.0;
-//                 this.cmd_posy = this.posy = 0.0;
-//                 this.cmd_posz = this.posz = 0.0;
-//                 this.cmd_posa = this.posa = 0.0;
-//                 this.cmd_posb = this.posb = 0.0;
-//                 callback();
-//             } catch (error) {
-//                 callback(error);
-//             }
-//         }.bind(this)
-//     );
-// };
-
-// exports.Z6 = function (args, callback) {
-//     this.machine.driver.get(
-//         "mpo",
-//         async function (err, MPO) {
-//             if (err) {
-//                 return callback(err);
-//             }
-//             var z6Obj = {};
-//             var unitConv = 1.0;
-//             if (this.machine.driver.status.unit === "in") {
-//                 // inches
-//                 unitConv = 0.039370079;
-//             }
-//             z6Obj.g55x = Number((MPO.x * unitConv).toFixed(5));
-//             z6Obj.g55y = Number((MPO.y * unitConv).toFixed(5));
-//             z6Obj.g55z = Number((MPO.z * unitConv).toFixed(5));
-//             // No unit conversion
-//             z6Obj.g55a = Number(MPO.a.toFixed(5));
-//             z6Obj.g55b = Number(MPO.b.toFixed(5));
-//             z6Obj.g55c = Number(MPO.c.toFixed(5));
-//             try {
-//                 await config.driver.setManyWrapper(z6Obj);
-//                 this.cmd_posx = this.posx = 0.0;
-//                 this.cmd_posy = this.posy = 0.0;
-//                 this.cmd_posz = this.posz = 0.0;
-//                 this.cmd_posa = this.posa = 0.0;
-//                 this.cmd_posb = this.posb = 0.0;
-//                 this.cmd_posc = this.posc = 0.0;
-//                 callback();
-//             } catch (error) {
-//                 callback(error);
-//             }
-//         }.bind(this)
-//     );
-// };
-
-////## update ZT to cover all axes 2/4/22, will still need to attend to U,V,W
+// Will need to attend to U,V,W at some point
 exports.ZT = async function (args, callback) {
     var ztObj = {};
     ztObj.g55x = 0.0;

--- a/runtime/opensbp/commands/zero.js
+++ b/runtime/opensbp/commands/zero.js
@@ -24,9 +24,11 @@ exports.ZY = function (args, callback) {
 };
 
 exports.ZZ = function (args, callback) {
-    const axes = [];
-    axes[2] = 0;
-    offsets.call(this, axes, callback);
+    //const axes = [];
+    //axes[2] = 0;
+    args = [];
+    args[2] = 0;
+    offsets.call(this, args, callback);
 };
 
 exports.ZA = function (args, callback) {
@@ -92,7 +94,36 @@ exports.Z6 = function (args, callback) {
     offsets.call(this, axes, callback);
 };
 
-// Will need to attend to U,V,W at some point
+// // Will need to attend to U,V,W at some point
+// exports.ZT = async function (args, callback) {
+//     var ztObj = {};
+//     ztObj.g55x = 0.0;
+//     ztObj.g55y = 0.0;
+//     ztObj.g55z = 0.0;
+//     ztObj.g55a = 0.0;
+//     ztObj.g55b = 0.0;
+//     ztObj.g55c = 0.0;
+//     this.emit_gcode("G28.3 X0 Y0 Z0 A0 B0 C0");
+//     try {
+//         await config.driver.setManyWrapper(ztObj);
+//         this.cmd_posx = this.posx = 0.0;
+//         this.cmd_posy = this.posy = 0.0;
+//         this.cmd_posz = this.posz = 0.0;
+//         this.cmd_posa = this.posa = 0.0;
+//         this.cmd_posb = this.posb = 0.0;
+//         this.cmd_posc = this.posc = 0.0;
+//         // TODO: Do we need this report on ZT CMD?
+//         // If so and callback should follow report we will need to async/await wrapper that as well.
+//         this.driver.requestStatusReportWrapper(function(report) {
+//         	log.debug("report = " + JSON.stringify(report));
+//         	callback();
+//         });
+//         callback();
+//     } catch (error) {
+//         callback(error);
+//     }
+// };
+
 exports.ZT = async function (args, callback) {
     var ztObj = {};
     ztObj.g55x = 0.0;
@@ -112,10 +143,11 @@ exports.ZT = async function (args, callback) {
         this.cmd_posc = this.posc = 0.0;
         // TODO: Do we need this report on ZT CMD?
         // If so and callback should follow report we will need to async/await wrapper that as well.
-        // this.driver.requestStatusReport(function(report) {
-        // 	log.debug("report = " + JSON.stringify(report));
-        // 	callback();
-        // });
+        //        log.debug("Ready for Status Report request ... waiting");
+        //        await this.driver.requestStatusReportWrapper(function(report) {
+        //        	log.debug("report = " + JSON.stringify(report));
+        //        	callback();
+        //        });
         callback();
     } catch (error) {
         callback(error);

--- a/runtime/opensbp/commands/zero.js
+++ b/runtime/opensbp/commands/zero.js
@@ -1,15 +1,16 @@
 //var log = require("../../../log").logger("sbp");
-var config = require("../../../config");
 
 const { offsets } = require("./location");
 
 /* ZERO */
 
-// See Notes in location.js for offsetting and zeroing commands and functions
+// See Notes in location.js for zeroing commands and location-setting functions
+// ... Except for ZT, zeroing commands do a local zero by appropriately changing the G55 offset of the requested axis
+// .... as would be done in g-code with a G10 L2 P2 commant
 // U,V,W not yet covered!
 
 exports.ZX = function (args, callback) {
-    log.debug("####-> Calling Offsets for ZX");
+    log.debug("Calling Offsets for ZX");
     args = [];
     args[0] = 0;
     offsets.call(this, args, callback);
@@ -22,7 +23,7 @@ exports.ZY = function (args, callback) {
 };
 
 exports.ZZ = function (args, callback) {
-    log.debug("####-> Calling Offsets for ZZ");
+    log.debug("Calling Offsets for ZZ");
     args = [];
     args[2] = 0;
     offsets.call(this, args, callback);
@@ -54,7 +55,7 @@ exports.Z2 = function (args, callback) {
 };
 
 exports.Z3 = function (args, callback) {
-    log.debug("####-> Calling Offsets for Z3");
+    log.debug("Calling Offsets for Z3");
     args = [];
     args[0] = 0;
     args[1] = 0;
@@ -93,31 +94,18 @@ exports.Z6 = function (args, callback) {
 };
 
 exports.ZT = async function (args, callback) {
-    var ztObj = {};
-    ztObj.g55x = 0.0;
-    ztObj.g55y = 0.0;
-    ztObj.g55z = 0.0;
-    ztObj.g55a = 0.0;
-    ztObj.g55b = 0.0;
-    ztObj.g55c = 0.0;
-    this.emit_gcode("G28.3 X0 Y0 Z0 A0 B0 C0");
-    try {
-        await config.driver.setManyWrapper(ztObj);
-        this.cmd_posx = this.posx = 0.0;
-        this.cmd_posy = this.posy = 0.0;
-        this.cmd_posz = this.posz = 0.0;
-        this.cmd_posa = this.posa = 0.0;
-        this.cmd_posb = this.posb = 0.0;
-        this.cmd_posc = this.posc = 0.0;
-        // TODO: Do we need this report on ZT CMD?
-        // If so and callback should follow report we will need to async/await wrapper that as well.
-        //        log.debug("Ready for Status Report request ... waiting");
-        //        await this.driver.requestStatusReportWrapper(function(report) {
-        //        	log.debug("report = " + JSON.stringify(report));
-        //        	callback();
-        //        });
-        callback();
-    } catch (error) {
-        callback(error);
-    }
+    args = [];
+    args[0] = 0;
+    args[1] = 0;
+    args[2] = 0;
+    args[3] = 0;
+    args[4] = 0;
+    args[5] = 0;
+    args[6] = 0;
+    args[7] = 0;
+    args[8] = 0;
+    args[9] = 0;
+    args[10] = 0;
+    args[11] = 0;
+    offsets.call(this, args, callback);
 };

--- a/runtime/opensbp/commands/zero.js
+++ b/runtime/opensbp/commands/zero.js
@@ -92,36 +92,6 @@ exports.Z6 = function (args, callback) {
     offsets.call(this, args, callback);
 };
 
-// // Will need to attend to U,V,W at some point
-// exports.ZT = async function (args, callback) {
-//     var ztObj = {};
-//     ztObj.g55x = 0.0;
-//     ztObj.g55y = 0.0;
-//     ztObj.g55z = 0.0;
-//     ztObj.g55a = 0.0;
-//     ztObj.g55b = 0.0;
-//     ztObj.g55c = 0.0;
-//     this.emit_gcode("G28.3 X0 Y0 Z0 A0 B0 C0");
-//     try {
-//         await config.driver.setManyWrapper(ztObj);
-//         this.cmd_posx = this.posx = 0.0;
-//         this.cmd_posy = this.posy = 0.0;
-//         this.cmd_posz = this.posz = 0.0;
-//         this.cmd_posa = this.posa = 0.0;
-//         this.cmd_posb = this.posb = 0.0;
-//         this.cmd_posc = this.posc = 0.0;
-//         // TODO: Do we need this report on ZT CMD?
-//         // If so and callback should follow report we will need to async/await wrapper that as well.
-//         this.driver.requestStatusReportWrapper(function(report) {
-//         	log.debug("report = " + JSON.stringify(report));
-//         	callback();
-//         });
-//         callback();
-//     } catch (error) {
-//         callback(error);
-//     }
-// };
-
 exports.ZT = async function (args, callback) {
     var ztObj = {};
     ztObj.g55x = 0.0;

--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -143,6 +143,15 @@ SBPRuntime.prototype.disconnect = function () {
     }
 
     if (this.ok_to_disconnect) {
+        log.debug(
+            "various posx's: global>" +
+                global.posx +
+                " driver>" +
+                this.driver.status.posx +
+                " machine>" +
+                this.machine.status.posx
+        );
+
         this.driver.removeListener("status", this.status_handler);
         this.machine = null;
         this.driver = null;
@@ -1674,14 +1683,27 @@ SBPRuntime.prototype.evaluateSystemVariable = function (v) {
         // To get location data expeditiously these were changed to read driver (G2) status rather than machine
         // or runtime status. This works within files, but may otherwise create issues?
         case 1: // X Location
-            return this.driver.status.posx;
-        //return this.machine.status.posx;
+            log.debug(
+                "various posx's: global>" +
+                    this.posx +
+                    " driver>" +
+                    this.driver.status.posx +
+                    " machine>" +
+                    this.machine.status.posx
+            );
+            //                " runtime>" + CUR_RUNTIME.posx);
+            //            return global.posx;
+            return this.posx;
+        //            return this.driver.status.posx;
+        //            return this.machine.status.posx;
 
         case 2: // Y Location
             return this.driver.status.posy;
 
         case 3: // Z Location
-            return this.driver.status.posz;
+            //  log.debug("my Current GLOBAL Z loc = " + global.posz + "  " + posz);
+            return this.posz;
+        //            return this.driver.status.posz;
 
         case 4: // A Location
             return this.driver.status.posa;
@@ -1915,10 +1937,7 @@ SBPRuntime.prototype.emit_gcode = function (s) {
         // eslint-disable-next-line no-redeclare
         var n = this.pc;
     }
-    if (!s.includes("G10")) {
-        this.gcodesPending = true;
-    }
-    //this.gcodesPending = true;
+    this.gcodesPending = true;
     var temp_n = n + 20; ////## save low numbers for prepend/postpend; being done in util for gcode?
     var gcode = "N" + temp_n + " " + s;
     log.debug("emit_gcode: " + gcode);

--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -1691,19 +1691,15 @@ SBPRuntime.prototype.evaluateSystemVariable = function (v) {
                     " machine>" +
                     this.machine.status.posx
             );
-            //                " runtime>" + CUR_RUNTIME.posx);
-            //            return global.posx;
-            //            return this.posx;
             return this.driver.status.posx;
-        //            return this.machine.status.posx;
 
         case 2: // Y Location
             return this.driver.status.posy;
 
         case 3: // Z Location
             //  log.debug("my Current GLOBAL Z loc = " + global.posz + "  " + posz);
-            return this.posz;
-        //            return this.driver.status.posz;
+            //return this.posz;
+            return this.driver.status.posz;
 
         case 4: // A Location
             return this.driver.status.posa;

--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -1666,26 +1666,28 @@ SBPRuntime.prototype.evaluateSystemVariable = function (v) {
     if (v === undefined) {
         return undefined;
     }
-
     if (v.type != "system_variable") {
         return;
     }
     var n = this._eval(v.expr);
     switch (n) {
+        // To get location data expeditiously these were changed to read driver (G2) status rather than machine
+        // or runtime status. This works within files, but may otherwise create issues?
         case 1: // X Location
-            return this.machine.status.posx;
+            return this.driver.status.posx;
+        //return this.machine.status.posx;
 
         case 2: // Y Location
-            return this.machine.status.posy;
+            return this.driver.status.posy;
 
         case 3: // Z Location
-            return this.machine.status.posz;
+            return this.driver.status.posz;
 
         case 4: // A Location
-            return this.machine.status.posa;
+            return this.driver.status.posa;
 
         case 5: // B Location
-            return this.machine.status.posb;
+            return this.driver.status.posb;
 
         case 6: // X Table Base
             return config.driver.get("g55x");

--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -1693,8 +1693,8 @@ SBPRuntime.prototype.evaluateSystemVariable = function (v) {
             );
             //                " runtime>" + CUR_RUNTIME.posx);
             //            return global.posx;
-            return this.posx;
-        //            return this.driver.status.posx;
+            //            return this.posx;
+            return this.driver.status.posx;
         //            return this.machine.status.posx;
 
         case 2: // Y Location

--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -1915,7 +1915,10 @@ SBPRuntime.prototype.emit_gcode = function (s) {
         // eslint-disable-next-line no-redeclare
         var n = this.pc;
     }
-    this.gcodesPending = true;
+    if (!s.includes("G10")) {
+        this.gcodesPending = true;
+    }
+    //this.gcodesPending = true;
     var temp_n = n + 20; ////## save low numbers for prepend/postpend; being done in util for gcode?
     var gcode = "N" + temp_n + " " + s;
     log.debug("emit_gcode: " + gcode);

--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -519,7 +519,7 @@ SBPRuntime.prototype._saveConfig = async function (callback) {
     }
 };
 
-// Save runtime driver settings to the opensbp settings file
+// Save runtime driver settings to settings files
 //   callback - Called when config has been written
 SBPRuntime.prototype._saveDriverSettings = async function (callback) {
     var g2_values = {};

--- a/runtime/opensbp/opensbp.js
+++ b/runtime/opensbp/opensbp.js
@@ -143,15 +143,6 @@ SBPRuntime.prototype.disconnect = function () {
     }
 
     if (this.ok_to_disconnect) {
-        log.debug(
-            "various posx's: global>" +
-                global.posx +
-                " driver>" +
-                this.driver.status.posx +
-                " machine>" +
-                this.machine.status.posx
-        );
-
         this.driver.removeListener("status", this.status_handler);
         this.machine = null;
         this.driver = null;


### PR DESCRIPTION
This PR improves the efficiency of OpenSBP calls to "system-location" variables (e.g. %(3)), particularly after events that have reset those location values, either by zeroing or setting to a new location (used in zeroing, homing, and probing routines).

The events include: using the Zeroing commands such as ZX or Z2 which work by setting a new working zero based on G55 offsets; or by doing a total machine and offset re-zeoring of everything to 0 with ZT; or by using ST to return locations to machine coordinates by removing all G55 offsets. And, especially with offset and machine-base management using VA.

VA is, in fact, the full parametric expression inclusively covering all of these calls. Previously various calls were handled separately and differently. Here, a new module, "./opensbp/commands/location.js", was created that commonly carries out all of these commands. 

VA is a 12 parameter command. The first 6 parameters represent a register of the working coordinate offsets (G55's) for the 6 axes; and the second 6 parameters represent a register of the current machine-base location. The zeroing commands use only the lower register (except ZT). VA and some other commands use both. All commands are now processed through two functions: offset() handles the G55 offsets (G10 L2 P2 in g-code); and, machine() handles the machine-base (G28.3 in g-code). These are handled sequentially in the location module in such a way that the G28.3 call to G2, if there are machine location changes, always happens before the final processing of the G55 changes, if there are any. There is a certain redundancy to the G10 work because of needing to manipulate both G2 storage and FabMo storage. It is the assertion of the FabMo variables that becomes available for processing by any system location-variable call. 

The FabMo-G2 location management system is described in the Command Reference (a working draft copy is in your Sb4 > Help). I'm updating this slightly and it will be in the next version of Sb4. A goal of the exposition there is to blend the use of the expression "table base coordinates" from Sb3 with "machine coordinates" from g-code … temporarily smearing them together a bit with the expression "machine base coordinates" …  as they are essentially the same.

This PR was developed with Handibot testing of a sample routine that does a quick check of zeroing and then reading location:

ZX   ' or VA, 0; or VA, .75
&loc = %(1) + 1
MX, &loc

Followed by making sure that macro C2 worked correctly over repeated trials. (I've slightly modified C2 and removed all the PAUSES ... it works!).

And, making sure that I could then run the dev-tests.

I then tested C2, C3 and lots of files on a Desktop.

There will shortly be a PR with new macro#2, macro#201 with slight changes.

And I'll post a new Sb4.

And a PR for updated Sb3_commands.json for FabMo.

*Setting Location and Zeroing in the Manual Keypad are also potentially related. But, I did not similarly change them to using the single location module (maybe someday). They work well and are tested; and they are initiated from a different runtime which creates a bit of a context conflict that will require some reorganization.
