### PR TITLE
Fix authentication

### DIFF
--- a/config/user_config.js
+++ b/config/user_config.js
@@ -235,12 +235,17 @@ UserConfig.prototype.add = function (username, password, callback) {
 
 //Maybe move this to the routes or whatever
 UserConfig.prototype.findOne = function (username, callback) {
-    username in this._cache
-        ? callback(null, this._cache[username])
-        : callback(
-              new Error("The username " + username + " is invalid."),
-              null
-          );
+    if (!username || typeof username !== "string") {
+        return callback(new Error("Invalid username."), null);
+    }
+    if (username in this._cache) {
+        return callback(null, this._cache[username]);
+    } else {
+        return callback(
+            new Error("The username " + username + " is invalid."),
+            null
+        );
+    }
 };
 
 // Get a map of all user ids to values

--- a/dashboard/apps/configuration.fma/js/user_manager.js
+++ b/dashboard/apps/configuration.fma/js/user_manager.js
@@ -24,7 +24,7 @@ function setupUserManager() {
       user = current_user;
       user_info= {
         user:{
-          id:current_user.username,
+          username:current_user.username,
           password:password
         }
       };
@@ -248,7 +248,7 @@ function refreshUsersListView(users){
           if(password===password_confirm){
             user_info= {
               user : {
-                id : user._id,
+                username : user.username,
                 password:password
               }
             };

--- a/engine.js
+++ b/engine.js
@@ -728,39 +728,6 @@ Engine.prototype.start = function (callback) {
                 );
             }.bind(this),
 
-            function setup_config_events(callback) {
-                config.engine.on(
-                    "change",
-                    function (evt) {
-                        if (evt.beacon_url) {
-                            this.beacon.set(
-                                "url",
-                                config.updater.get("beacon_url")
-                            );
-                        }
-                        //TODO ... as part of dealing with beacon
-                        ////## this 'once' generating can't read prop error on first config changes
-                        // If the tool name changes, report the change to beacon
-                        if (evt.name) {
-                            this.beacon.once("config");
-                        }
-
-                        // If beacon consent changes, let the beacon daemon know (possibly do a report)
-                        if (evt.consent_for_beacon) {
-                            this.beacon.set(
-                                "consent_for_beacon",
-                                evt.consent_for_beacon
-                            );
-                            log.info(
-                                "Consent for beacon is " +
-                                    evt.consent_for_beacon
-                            );
-                        }
-                    }.bind(this)
-                );
-                callback();
-            }.bind(this),
-
             // Kick off the server if all of the above went OK.
             function start_server(callback) {
                 log.info("Setting up the webserver...");

--- a/network/linux/raspberry-pi/index.js
+++ b/network/linux/raspberry-pi/index.js
@@ -632,8 +632,6 @@ RaspberryPiNetworkManager.prototype.setIdentity = function (
             function set_name(callback) {
                 if (identity.name) {
                     log.info("Setting network name to " + identity.name);
-                    // eslint-disable-next-line no-undef
-                    jedison("set name '" + identity.name + "'", callback);
                 } else {
                     callback(null);
                 }
@@ -651,11 +649,6 @@ RaspberryPiNetworkManager.prototype.setIdentity = function (
                 if (identity.password) {
                     log.info(
                         "Setting network password to " + identity.password
-                    );
-                    // eslint-disable-next-line no-undef
-                    jedison(
-                        "set password '" + identity.password + "'",
-                        callback
                     );
                 } else {
                     callback(null);

--- a/routes/authentication.js
+++ b/routes/authentication.js
@@ -148,8 +148,11 @@ var getCurrentUser = function (req, res, next) {
 // eslint-disable-next-line no-unused-vars
 var modifyUser = function (req, res, next) {
     var currentUser = authentication.getCurrentUser();
-    if (!req.params.id) {
-        res.send(200, { status: "error", message: "no username provided" });
+    if (!req.params.id || req.params.id === "undefined") {
+        res.send(200, {
+            status: "error",
+            message: "invalid username provided",
+        });
         return;
     }
     if (

--- a/routes/authentication.js
+++ b/routes/authentication.js
@@ -148,7 +148,7 @@ var getCurrentUser = function (req, res, next) {
 // eslint-disable-next-line no-unused-vars
 var modifyUser = function (req, res, next) {
     var currentUser = authentication.getCurrentUser();
-    if (!req.params.user.id || req.params.user.id === "undefined") {
+    if (!req.params.id || req.params.id === "undefined") {
         res.send(200, {
             status: "error",
             message: "invalid username provided",
@@ -168,7 +168,7 @@ var modifyUser = function (req, res, next) {
             return;
         }
         authentication.modifyUser(
-            req.params.user.id,
+            req.params.id,
             req.params.user,
             function (err, user) {
                 if (err) {

--- a/routes/authentication.js
+++ b/routes/authentication.js
@@ -1,4 +1,3 @@
-var log = require("../log").logger("authentication");
 var authentication = require("../authentication");
 var passport = authentication.passport;
 
@@ -68,10 +67,9 @@ var addUser = function (req, res, next) {
 };
 
 var logout = function (req, res, next) {
-    log.error(req);
     req.logout();
     authentication.setCurrentUser(null);
-    res.redirect("", next);
+    res.redirect("/", next);
     return;
 };
 

--- a/routes/authentication.js
+++ b/routes/authentication.js
@@ -148,18 +148,18 @@ var getCurrentUser = function (req, res, next) {
 // eslint-disable-next-line no-unused-vars
 var modifyUser = function (req, res, next) {
     var currentUser = authentication.getCurrentUser();
-    if (!req.params.id || req.params.id === "undefined") {
+    if (!req.params.user.id || req.params.user.id === "undefined") {
         res.send(200, {
             status: "error",
             message: "invalid username provided",
         });
         return;
     }
+    // if current user or admin
     if (
         currentUser &&
         (currentUser.username == req.params.username || currentUser.isAdmin)
     ) {
-        // if current user or admin
         if (!req.params.user) {
             res.send(200, {
                 status: "error",
@@ -168,7 +168,7 @@ var modifyUser = function (req, res, next) {
             return;
         }
         authentication.modifyUser(
-            req.params.id,
+            req.params.user.id,
             req.params.user,
             function (err, user) {
                 if (err) {

--- a/routes/authentication.js
+++ b/routes/authentication.js
@@ -158,7 +158,7 @@ var modifyUser = function (req, res, next) {
     // if current user or admin
     if (
         currentUser &&
-        (currentUser.username == req.params.username || currentUser.isAdmin)
+        (currentUser.username == req.params.id || currentUser.isAdmin)
     ) {
         if (!req.params.user) {
             res.send(200, {


### PR DESCRIPTION
This PR addresses a few things. in configuration->General->General Settings, changing the machine name was producing an uncaught exception because it was attempting to use an edison specific function in fabmo/network/linux/raspberry-pi/index.js. Also, there were some references to beacon which we removed a while back. Removed them.

Configuration->Users->Change Password was not working at all, nor was it allowing admin to change other users password. Any user can now change their own password, admin is the superuser and can change anyones password. Users that are assigned as admin can add users and change their password, but cannot change the superusers password. For testing:
- Logged in as admin, changed own password, logged out and logged back in with new password
- Logged in as admin, added a new user, logged out and logged back in as that user
- Logged in as admin, changed password of existing user, logged out and logged back in as that user with new password
- Logged in as user, added new user, logged out and logged back in as that user
- Logged in as user, added new user, changed their password, logged out and logged back in as that user with new password

