### PR TITLE
Fixes Brian's problem of accidentally dragging URLs from Editor Menu

### DIFF
--- a/dashboard/apps/editor.fma/js/editor.js
+++ b/dashboard/apps/editor.fma/js/editor.js
@@ -269,6 +269,10 @@ require('./cm-fabmo-modes.js');
 
     }); // document.ready
 
+    $("#topbar").on("dragstart", function(evt) {
+      evt.preventDefault();
+    });
+    
     $("#submit-immediate").click(function(evt) {
       evt.preventDefault();
       execute();


### PR DESCRIPTION
Fixes the problem Brian Owen reported he was having with frequently accidentally dragging the URL of menu items into the Editor. (Fix specifically only effects Editor)

I don't think this has made it into an issue yet.

Tested using editor, only.