### PR TITLE
Fix display of input actions in small DRO

### DIFF
--- a/dashboard/static/js/libs/fabmoui.js
+++ b/dashboard/static/js/libs/fabmoui.js
@@ -363,10 +363,14 @@
                         assignedAction === "stop" ||
                         assignedAction === "faststop"
                     ) {
-                        $("#inp-stop").css("visibility", "hidden");
+                        if (!stopIsOn) {
+                            $("#inp-stop").css("visibility", "hidden");
+                        }
                     }
                     if (assignedAction === "interlock") {
-                        $("#inp-interlock").css("visibility", "hidden");
+                        if (!intIsOn) {
+                            $("#inp-interlock").css("visibility", "hidden");
+                        }
                     }
                     $(selector)
                         .removeClass("on stopOn interlockOn")


### PR DESCRIPTION
This display bug came up in testing issue #1080 

It was noted that in the case that multiple inputs were selected for the same input action (e.g. STOP, INTERLOCK, or LIMIT) that the only for the highest number input did the colored word for the action appear in the small DRO, though the tool did perform the feed-hold and displayed the modal as appropriate.

This PR fixes the display for STOP, INTERLOCK (for LIMIT I have fixed the display in the pending PR branch)

As I was not able to replicate main phenomenon of the issue, it can be closed.