### PR TITLE
Better fix for missing locations in instance_config.json

### DIFF
--- a/config/instance_config.js
+++ b/config/instance_config.js
@@ -43,7 +43,8 @@ InstanceConfig.prototype.update = function (data, callback) {
 InstanceConfig.prototype.apply = function (callback) {
     try {
         var position = this.get("position");
-        if (position.length === 1) {
+        var keys = Object.keys(position);
+        if (keys.length < 1) {
             // if there is nothing in the object
             log.debug(
                 "Unable to Recover Previous Location! Setting Base Locations to 0.0"


### PR DESCRIPTION
This gets at one error that prevents FabMo starting, similar to problem Brian recently reported. 
Small fix to improve a previous version.

(Further cases may need to be covered for this or other config files.)