### PR TITLE
Add action keys (macros, simple commands) to keypad

### DIFF
--- a/dashboard/build/index.html
+++ b/dashboard/build/index.html
@@ -312,9 +312,9 @@
             </div>
 
             <div class="keypad-actions">
-              <div class="action-button" title="Do Z-Zero (Macro #2)">C2</div>
-              <div class="action-button" title="Do XYZ-Homing (Macro #3)">C3</div>
-              <div class="action-button" title="JH (Jog Home in XY)">JH</div>
+              <div class="action-button" id="action-1" title="Do Z-Zero (Macro #2)">C2</div>
+              <div class="action-button" id="action-2" title="Do XYZ-Homing (Macro #3)">C3</div>
+              <div class="action-button" id="action-3" title="JH (Jog Home in XY)">JH</div>
             </div>
 
           </div>

--- a/dashboard/build/index.html
+++ b/dashboard/build/index.html
@@ -256,7 +256,7 @@
       <div class="manual-drive-container">
         <div>
           <label class="noselect" id="title_goto" title="Click in box to enter axis location to send tool, or to set a new value for the current location. Zero button sets the current axis position to 0.000">
-              Click to 'GoTo' a location or to 'Set' a location
+              Click to: 'GoTo' location or 'Set' location
           </label>
         </div>
         <div class="read-out-container">
@@ -310,6 +310,13 @@
                 <span class="rotunits">o&nbsp;</span>
                 <div class="zero-button zero-c" title="set this axis to zero">zero</div>
             </div>
+
+            <div class="keypad-actions">
+              <div class="action-button" title="Do Z-Zero (Macro #2)">C2</div>
+              <div class="action-button" title="Do XYZ-Homing (Macro #3)">C3</div>
+              <div class="action-button" title="JH (Jog Home in XY)">JH</div>
+            </div>
+
           </div>
         </div>
         <div class="manual-right-side-container">

--- a/dashboard/static/css/style.css
+++ b/dashboard/static/css/style.css
@@ -1946,7 +1946,6 @@ input[type='range']:focus {
 
 .go-to-container span {
 	position: absolute;
-    text-align: center;
     width: 90%;
     top: 50%;
     left: 50%;
@@ -1956,11 +1955,12 @@ input[type='range']:focus {
 
 #title_goto {
     font-size: 1rem;
-    position: absolute;
+    /* position: absolute; */
     top: 1rem;
+	left: 5%;
     margin-top: -2rem;
-    margin-left: 2rem;
-    margin-bottom: 0.5rem;
+    /* margin-bottom: 0.5rem; */
+	margin-bottom: 1.5rem;
 }
 
 
@@ -2032,7 +2032,6 @@ input[type='range']:focus {
     background-color: #877b56;
     border-radius: 0 4px 4px 0;
     box-shadow: 0px 2px 0px #84743d, 0px 2px 4px rgba(0,0,0,.2);
-    text-shadow: 1px 1px 1px rgba(0,0,0,0.3);
     font-family: 'source_sans_proextralight';
 	transition: all .1s ease;
 	vertical-align:top;
@@ -2044,6 +2043,36 @@ input[type='range']:focus {
 	color: #eee;
 }
 
+.keypad-actions {
+	display: table-row;
+	font-size: 0;
+	text-align: center;
+	height: 50px;
+}
+
+.action-button{
+	cursor: pointer;
+    color: #eee;
+    display: inline-block;
+    font-size: 23px;
+	margin-top: 1.5rem;
+    margin-left: 0.3rem;
+	margin-right: 0.3rem;
+	width: 50px;
+    padding: 3px 5px 3px;
+    background-color: #035b1c;
+    border-radius: 10px 10px 10px 10px;
+    box-shadow: 0px 2px 0px #84743d, 0px 2px 4px rgba(0,0,0,.2);
+    font-family: 'Droid_Sans_Mono';
+	transition: all .1s ease;
+	vertical-align: middle;
+}
+
+.action-button:active {
+	margin-top: 1px;
+	box-shadow: 0px 1px 0px #ce6402, 0px 1px 1px rgba(0,0,0,.9);
+	color: #eee;
+}
 
 
 
@@ -2168,8 +2197,8 @@ input[type='range']:focus {
 	}
 
     #title_goto {
-        margin-top: 0rem;
-        margin-left: 25%;
+		left: 15%;
+		margin-top: 0rem;
         margin-bottom: -0.5rem;    
     }
 

--- a/dashboard/static/css/style.css
+++ b/dashboard/static/css/style.css
@@ -1955,12 +1955,11 @@ input[type='range']:focus {
 
 #title_goto {
     font-size: 1rem;
-    /* position: absolute; */
     top: 1rem;
 	left: 5%;
+	padding-bottom: 1rem;
     margin-top: -2rem;
-    /* margin-bottom: 0.5rem; */
-	margin-bottom: 1.5rem;
+	margin-bottom: 1.2rem;
 }
 
 
@@ -2055,11 +2054,11 @@ input[type='range']:focus {
     color: #eee;
     display: inline-block;
     font-size: 23px;
-	margin-top: 1.5rem;
+	margin-top: .75rem;
+	margin-bottom: 1.5rem;
     margin-left: 0.3rem;
 	margin-right: 0.3rem;
 	width: 50px;
-    padding: 3px 5px 3px;
     background-color: #035b1c;
     border-radius: 10px 10px 10px 10px;
     box-shadow: 0px 2px 0px #84743d, 0px 2px 4px rgba(0,0,0,.2);


### PR DESCRIPTION
Since Sb4 will have user configurable shortcuts, for the moment the keypad only contains a set of hardcoded basic shortcut actions. This could be expanded or made to be usable configurable. Here for testing at the moment.

Note that the difficulty implementing here is that the keypad and Manual Mode must be cleanly exited before calling a macro, file or motion.