### PR TITLE
Prelim network changes for mini-screen control

### DIFF
--- a/network.js
+++ b/network.js
@@ -13,7 +13,7 @@ var log = require("./log").logger("network");
 // If no such manager is defined or there's a problem creating it, an exception is thrown.
 exports.createNetworkManager = function (name, callback) {
     // The OS comes from node, and is something like 'linux' or 'darwin'
-    // The platform is defined in the updater configuration - it's something like 'edison' or 'westinghouse' or 'generic'
+    // The platform is now defined in the engine configuration - it's something like 'raspberry-pi'
     var OS = config.platform;
     var PLATFORM = config.engine.get("platform");
     log.info("OS is:" + OS);
@@ -28,7 +28,7 @@ exports.createNetworkManager = function (name, callback) {
         nm.platform = PLATFORM;
         if (!name && nm.platform === "raspberry-pi") {
             // eslint-disable-next-line no-unused-vars
-            nm.set_uuid(function (name) {
+            nm.set_serialnum(function (name) {
                 callback(null, nm);
             });
         } else {

--- a/network/linux/raspberry-pi/commands.js
+++ b/network/linux/raspberry-pi/commands.js
@@ -20,6 +20,7 @@ class commands {
         exec("ifconfig uap0 " + ip, callback);
     }
 
+    // use this plus systemctl start hostapd to start the AP
     static addApInterface(callback) {
         exec("iw phy phy0 interface add uap0 type __ap", callback);
     }
@@ -55,14 +56,14 @@ class commands {
     static hostapd(options, callback) {
         var commands = [];
 
-        // Known good options for the Raspberry PI 3.  If you are using the
-        // Raspberry PI Zero the driver value might need to be different.
+        // Known good options for the Raspberry PI 3.
+        // (obvious ssid so we can recognize this origin; ssid should come from the config.engine file)
         var defaultOptions = {
             driver: "nl80211",
             channel: 6,
             hw_mode: "g",
             interface: "uap0",
-            ssid: "fabmo",
+            ssid: "fa3mo",
         };
 
         var finalOptions = Object.assign(defaultOptions, options);


### PR DESCRIPTION
Changes to networking so that FabMo only handles joining wifi networks and populates the SSID/name of in the wifi network list of computer. Still pretty messy with lots of debugging stuff plus a hiccup or two during the update-ssid process. Still, it works in most scenarios.