### PR TITLE
Static server: revalidate /approot app assets so updates aren't cache…

### DIFF
--- a/routes/dashboard.js
+++ b/routes/dashboard.js
@@ -218,16 +218,24 @@ module.exports = function (server) {
     server.post("/apps/:id/config", postAppConfig);
     server.del("/apps/:id", deleteApp);
     server.get("/apps/:id/files", listAppFiles);
+    // Apps are served from stable /approot paths (no version stamp like the
+    // dashboard bundle gets), and their assets aren't content-hashed, so a
+    // long max-age would leave customers staring at a stale app for up to an
+    // hour after an update. maxAge: 0 makes the browser revalidate every load;
+    // static.js answers unchanged files with a cheap 304, so updates appear on
+    // the next refresh without a full re-download each time.
     server.get(
         "/approot/*",
         static({
             directory: config.getDataDir("approot"),
+            maxAge: 0,
         })
     );
     server.get(
         "/approot*",
         static({
             directory: config.getDataDir("approot"),
+            maxAge: 0,
         })
     );
     server.get("/updater", updater);

--- a/static.js
+++ b/static.js
@@ -69,8 +69,30 @@ function serveStatic(options) {
             res.handledGzip();
         }
 
-        var fstream = fs.createReadStream(file + (isGzip ? ".gz" : ""));
         var maxAge = opts.maxAge === undefined ? 3600 : opts.maxAge;
+
+        // Conditional GET. If the client already holds a copy at least as new
+        // as the file on disk, answer 304 and skip the body. This is what makes
+        // a low/zero maxAge cheap: the browser revalidates on every load, but an
+        // unchanged file costs a tiny header round-trip instead of a full
+        // re-download. mtime is compared at whole-second precision because HTTP
+        // dates (If-Modified-Since / Last-Modified) carry no milliseconds — a
+        // sub-second mtime would otherwise always look "newer" and never match.
+        var ims = req.headers["if-modified-since"];
+        if (ims) {
+            var since = Date.parse(ims);
+            var mtimeSec = Math.floor(stats.mtime.getTime() / 1000) * 1000;
+            if (!isNaN(since) && mtimeSec <= since) {
+                res.cache({ maxAge: maxAge });
+                res.set("Last-Modified", stats.mtime);
+                res.writeHead(304);
+                res.end();
+                next(false);
+                return;
+            }
+        }
+
+        var fstream = fs.createReadStream(file + (isGzip ? ".gz" : ""));
         // eslint-disable-next-line no-unused-vars
         fstream.once("open", function (fd) {
             res.cache({ maxAge: maxAge });


### PR DESCRIPTION
…d stale

FabMo's static.js is a fork of restify's serveStatic, and it inherited restify's default Cache-Control: public, max-age=3600. The dashboard bundle escapes staleness because it's served under a version-stamped path (routes/index.js rewrites every request to /<engine-version>/...), so an engine update changes the URL and busts the cache. The .fma apps never got that treatment: they're served from stable /approot/... paths with non-hashed assets, so after an in-place app update the browser kept serving the year-old JS for up to an hour. Worse, apps run in iframes, where a parent hard-reload doesn't reliably bypass cache for nested sub-resources -- so the only reliable workaround was incognito.

Fix the app path specifically:

- routes/dashboard.js: serve both /approot routes with maxAge: 0, so the browser revalidates app assets on every load instead of trusting a stale copy. The dashboard route is left on the 3600 default since it's already version-busted.

- static.js: add conditional-GET (If-Modified-Since -> 304) support so the zero max-age is cheap -- an unchanged file costs a tiny header round-trip instead of a full re-download. mtime is compared at whole-second precision to match HTTP date granularity. This also benefits every other static response (dashboard included) once its max-age expires.