### PR TITLE
Print output widget: appear on demand, dismissable

### DIFF
--- a/dashboard/build/index.html
+++ b/dashboard/build/index.html
@@ -97,13 +97,14 @@
           </section>
 
           <!-- ***** PRINT OUTPUT widget (docked in top bar; can pull off into a
-               floating modal). Fed by the SBP PRINT command. ***** -->
-          <div id="print-widget" class="print-widget docked" title="Print output from running files">
+               floating modal). Fed by the SBP PRINT command. Starts dismissed;
+               JS shows it when a file actually prints. ***** -->
+          <div id="print-widget" class="print-widget docked dismissed" title="Print output from running files">
             <div class="print-widget-dockline" id="print-widget-dockline">
               <div class="print-widget-header">
-                <span class="print-widget-title">Machine output:</span>
+                <span class="print-widget-title">File Output:</span>
                 <span class="print-widget-grip" id="print-widget-grip" title="Drag to pull off the bar">&#8942;&#8942;&#8942;</span>
-                <button type="button" class="print-widget-close" id="print-widget-close" title="Close (return to top bar)" aria-label="Close">&#10005;</button>
+                <button type="button" class="print-widget-close" id="print-widget-close" title="Dismiss (reappears when a file prints output)" aria-label="Dismiss">&#10005;</button>
               </div>
               <div class="print-widget-outputrow">
                 <button type="button" class="print-widget-expand" id="print-widget-expand" title="Expand to see past messages" aria-label="Expand print output">&#9662;</button>

--- a/dashboard/static/css/style.css
+++ b/dashboard/static/css/style.css
@@ -94,13 +94,25 @@ label {
 /* ===== PRINT OUTPUT widget — docked in the top bar ========================
    Absolutely positioned within the fixed .tab-bar; JS sets left/right so it
    fills the gap between the machine name and the mini-DRO. */
+/* Dismissed (or nothing printed yet): gone from the UI entirely. JS removes
+   the class when a PRINT line arrives. !important so it beats the inline
+   visibility/size styles the docked layout code sets. */
+.print-widget.dismissed {
+    display: none !important;
+}
 .print-widget.docked {
     position: absolute;
     top: 0;
-    height: 56px;
+    height: 56px;               /* fallback; JS matches the keypad button's box */
     display: flex;
     align-items: flex-end;      /* sit the module at the bottom of the bar */
     z-index: 1;                 /* tab-bar itself is 1005 */
+}
+/* When docked, the frame fills the widget box exactly — JS sizes/positions
+   that box to match the visible face of the keypad button to its right. */
+.print-widget.docked .print-widget-dockline {
+    height: 100%;
+    justify-content: center;
 }
 /* Hide on small screens (replaces the Foundation show-for-medium-up class,
    which forced display:inherit and broke the flex alignment). */
@@ -118,7 +130,7 @@ label {
        docked widget reads as one detachable module. */
     background-color: rgba(0, 0, 0, 0.18);
     border: 1px solid rgba(255, 255, 255, 0.25);
-    border-radius: 4px;
+    border-radius: 5px;         /* matches the keypad button's corner radius */
     color: #ffffff;
     font-family: "Droid_Sans_Mono", monospace;
     line-height: 1.2;              /* override .tab-bar's inherited 45px line-height */
@@ -234,7 +246,7 @@ label {
 .print-widget.docked.expanded .print-widget-stream {
     display: block;
     position: absolute;
-    top: 52px;                 /* just below the module (bar 56 - 4px gap) */
+    top: 100%;                 /* hang just below the module frame */
     right: 0;
     width: 100%;
     max-height: 50vh;
@@ -247,7 +259,7 @@ label {
 .print-widget.docked.expanded .print-widget-expand {
     transform: rotate(180deg);  /* caret flips when open */
 }
-/* Close (X) — only in the floating modal. */
+/* Close (X) — dismisses the widget entirely (docked or floating). */
 .print-widget-close {
     flex: 0 0 auto;
     margin: 0 0 0 8px;
@@ -262,7 +274,10 @@ label {
     cursor: pointer;
 }
 .print-widget-close:hover { color: #ff6b6b; }
-.print-widget.docked .print-widget-close { display: none; }
+.print-widget.docked .print-widget-close {
+    font-size: 11px;
+    margin-left: 6px;
+}
 /* ===== Floating modal (pulled off the bar) ================================= */
 .print-widget.floating {
     position: fixed;

--- a/dashboard/static/js/main.js
+++ b/dashboard/static/js/main.js
@@ -1293,6 +1293,8 @@ function getManualNudgeIncrement(move) {
 // between the machine name and the mini-DRO; (Phase B) an expand control opens
 // a stream dropdown; (Phase C) it can be dragged off into a floating modal.
 // Fed by the SBP PRINT command over the data_send 'print'/'print_clear' bus.
+// Absent from the UI until a file prints something; the X dismisses it
+// completely (persisted) until the next PRINT arrives.
 function setupPrintWidget(engine) {
     var STORAGE_KEY = "fabmo_print_output";
     var MAX_LINES = 200; // hard cap on retained lines
@@ -1310,6 +1312,16 @@ function setupPrintWidget(engine) {
         if (saved) lines = JSON.parse(saved) || [];
     } catch (e) {
         lines = [];
+    }
+
+    // The widget only exists in the UI while a file has printed something and
+    // the user hasn't dismissed it. A new PRINT line always brings it back.
+    var dismissed = false;
+
+    function updateVisibility() {
+        var show = lines.length > 0 && !dismissed;
+        widget.classList.toggle("dismissed", !show);
+        if (show) layout();
     }
 
     function persist() {
@@ -1410,6 +1422,7 @@ function setupPrintWidget(engine) {
             false
         );
         renderStream();
+        updateVisibility();
         layout();
     }
 
@@ -1425,6 +1438,12 @@ function setupPrintWidget(engine) {
         lines.unshift(s);
         if (lines.length > MAX_LINES) lines.length = MAX_LINES;
         persist();
+        // A file printing output always re-summons a dismissed widget.
+        if (dismissed) {
+            dismissed = false;
+            persistState();
+        }
+        updateVisibility();
         renderStream();
         updateLatest(s, false, true); // animated scroll-in (docked)
         flash();
@@ -1473,8 +1492,27 @@ function setupPrintWidget(engine) {
         widget.style.left = "auto";
         widget.style.right = rightPx + "px";
         widget.style.width = Math.max(0, width) + "px";
-        // Sit the docked module a few pixels above the bar's bottom edge.
-        widget.style.paddingBottom = BOTTOM_GAP + "px";
+        // Match the keypad button's visible face vertically. The PNG has
+        // transparent padding: the yellow rect starts 55/256 down the image
+        // and is 171/256 of its height, so compute that box and size the
+        // widget to it (same height, same top edge, same corner treatment).
+        var visTop = null;
+        var visHeight = null;
+        if (keypadBtn && rightRect && rightAnchor === keypadBtn && rightRect.height > 0) {
+            visTop = rightRect.top + rightRect.height * (55 / 256);
+            visHeight = rightRect.height * (171 / 256);
+        }
+        if (visTop !== null && visTop >= barRect.top && visTop + visHeight <= barRect.bottom + 2) {
+            widget.style.top = Math.round(visTop - barRect.top) + "px";
+            widget.style.height = Math.round(visHeight) + "px";
+            widget.style.paddingBottom = "0px";
+        } else {
+            // Keypad missing or off the bar (small screens): fall back to
+            // bottom-aligned in the bar as before.
+            widget.style.top = "0px";
+            widget.style.height = "";
+            widget.style.paddingBottom = BOTTOM_GAP + "px";
+        }
         // Hide if there isn't enough room to be useful (small screens).
         widget.style.visibility = width < 80 ? "hidden" : "visible";
     }
@@ -1524,6 +1562,7 @@ function setupPrintWidget(engine) {
                 JSON.stringify({
                     floating: widget.classList.contains("floating"),
                     expanded: widget.classList.contains("expanded"),
+                    dismissed: dismissed,
                     x: floatPos ? floatPos.x : null,
                     y: floatPos ? floatPos.y : null,
                 })
@@ -1551,6 +1590,7 @@ function setupPrintWidget(engine) {
         widget.classList.add("floating");
         widget.style.right = "";
         widget.style.width = "";
+        widget.style.height = "";
         widget.style.paddingBottom = "";
         widget.style.visibility = "";
         document.body.appendChild(widget);
@@ -1651,9 +1691,17 @@ function setupPrintWidget(engine) {
             persistState();
         });
     }
-    // Close (X) — redock the floating modal.
+    // Close (X) — dismiss the widget from the UI entirely. It returns the
+    // next time a file prints output. A floating modal is redocked first so
+    // it reappears in the bar, not hovering mid-screen.
     if (closeBtn) {
-        closeBtn.addEventListener("click", redock);
+        closeBtn.addEventListener("click", function () {
+            if (!isDocked()) redock();
+            widget.classList.remove("expanded");
+            dismissed = true;
+            persistState();
+            updateVisibility();
+        });
     }
     // Click outside collapses the docked dropdown.
     document.addEventListener("click", function (e) {
@@ -1682,6 +1730,7 @@ function setupPrintWidget(engine) {
             st = null;
         }
         if (!st) return;
+        dismissed = !!st.dismissed;
         if (st.floating) {
             detach(st.x != null ? st.x : 80, st.y != null ? st.y : 80);
         } else if (st.expanded) {


### PR DESCRIPTION
The docked File Output module was permanently present in the top bar even when nothing had ever printed. Now it is absent from the UI entirely until a file emits a PRINT line, and the X (now available docked as well as floating) dismisses it completely — persisted across reloads — until the next PRINT re-summons it. CLEARPRINT empties the buffer and hides it. A floating modal is redocked on dismiss so it reappears in the bar.


Claude-Session: https://claude.ai/code/session_014rxaGD2cnnZhR5H1ZourNZ