### PR TITLE
Soft limits: skip Z-max check when unzeroed, add Z-span check

### DIFF
--- a/dashboard/apps/job_manager.fma/js/job_manager.js
+++ b/dashboard/apps/job_manager.fma/js/job_manager.js
@@ -392,7 +392,12 @@ function setFirstCard(job) {
     var $play = $('.play-button').first();
     $play.addClass('exceeds-limits');
     var msg = check.violations
-      .map(function (v) { return v.axis.toUpperCase() + ' ' + v.direction + ' by ' + v.overage.toFixed(2); })
+      .map(function (v) {
+        if (v.direction === 'span') {
+          return v.axis.toUpperCase() + ' range of file exceeds machine travel by ' + v.overage.toFixed(2);
+        }
+        return v.axis.toUpperCase() + ' ' + v.direction + ' by ' + v.overage.toFixed(2);
+      })
       .join(', ');
     // Real DOM badge (instead of ::after) so it can carry its own tooltip —
     // the play icon's own `title` would otherwise shadow a title set on the
@@ -432,9 +437,25 @@ function evaluateSoftLimits(jobBounds, cfg) {
       violations.push({ axis: a, direction: 'min', overage: envMin - (bMin + off) });
     }
   });
+  // g55z of exactly 0 means Z has never been zeroed (a real zero always lands
+  // at a fractional offset) — skip the Z check rather than flag every file.
   var bMaxZ = jobBounds.max && jobBounds.max.z;
-  if (typeof bMaxZ === 'number' && bMaxZ + g55.z > 0) {
+  if (typeof bMaxZ === 'number' && g55.z !== 0 && bMaxZ + g55.z > 0) {
     violations.push({ axis: 'z', direction: 'max', overage: bMaxZ + g55.z });
+  }
+  // Zeroed or not, the file's own Z range is a hard constraint: if it spans
+  // more than the machine's total Z travel, it goes out of bounds no matter
+  // where Z is zeroed. Travel is ceiling (machine 0 — zmax is not meaningful
+  // for Z) down to envelope.zmin.
+  var bMinZ = jobBounds.min && jobBounds.min.z;
+  if (
+    typeof bMaxZ === 'number' && typeof bMinZ === 'number' &&
+    typeof envelope.zmin === 'number'
+  ) {
+    var zTravel = -envelope.zmin;
+    if (zTravel > 0 && bMaxZ - bMinZ > zTravel) {
+      violations.push({ axis: 'z', direction: 'span', overage: bMaxZ - bMinZ - zTravel });
+    }
   }
   return { exceeds: violations.length > 0, violations: violations };
 }

--- a/dashboard/apps/previewer.fma/js/gui.js
+++ b/dashboard/apps/previewer.fma/js/gui.js
@@ -94,8 +94,14 @@ module.exports = function(callbacks) {
     var u = units || '';
     for (var i = 0; i < violations.length; i++) {
       var v = violations[i];
-      var line = v.axis.toUpperCase() + ' exceeds ' + v.direction +
-                 ' by ' + v.overage.toFixed(2) + ' ' + u;
+      var line;
+      if (v.direction === 'span') {
+        line = v.axis.toUpperCase() + ' range of file exceeds machine travel by ' +
+               v.overage.toFixed(2) + ' ' + u;
+      } else {
+        line = v.axis.toUpperCase() + ' exceeds ' + v.direction +
+               ' by ' + v.overage.toFixed(2) + ' ' + u;
+      }
       $('<li>').text(line).appendTo($list);
     }
     show(self.softLimitWarning, true);

--- a/dashboard/apps/previewer.fma/js/viewer.js
+++ b/dashboard/apps/previewer.fma/js/viewer.js
@@ -128,6 +128,18 @@ module.exports = function(container) {
               violations.push({ axis: 'z', direction: 'max', overage: machineMaxZ });
           }
       }
+      // Zeroed or not, the file's own Z range is a hard constraint: if it spans
+      // more than the machine's total Z travel, it goes out of bounds no matter
+      // where Z is zeroed. Travel is ceiling (machine 0 — zmax is not
+      // meaningful for Z) down to envelope.zmin.
+      var bMinZ = bounds.min.z;
+      if (typeof bMaxZ === 'number' && typeof bMinZ === 'number' &&
+          typeof env.zmin === 'number') {
+          var zTravel = -env.zmin;
+          if (zTravel > 0 && bMaxZ - bMinZ > zTravel) {
+              violations.push({ axis: 'z', direction: 'span', overage: bMaxZ - bMinZ - zTravel });
+          }
+      }
       if (violations.length) {
           self.gui.showSoftLimitWarning(violations, softLimits.units);
       } else {

--- a/runtime/bounds.js
+++ b/runtime/bounds.js
@@ -122,11 +122,29 @@ function checkAgainstEnvelope(bounds, envelope, g55) {
     // ceiling is the invariant table-base top. No Z min check: low-Z in a CAM
     // file is cut depth, which depends on bit length and would noise-fire on
     // normal jobs.
+    // g55z of exactly 0 means Z has never been zeroed (a real zero always
+    // lands at a fractional offset below the top prox) — skip the Z check
+    // rather than flag every file's safe-height pullup.
     var bMaxZ = bounds.max.z;
-    if (typeof bMaxZ === "number") {
-        var offZ = (g55 && typeof g55.z === "number") ? g55.z : 0;
+    var offZ = (g55 && typeof g55.z === "number") ? g55.z : 0;
+    if (typeof bMaxZ === "number" && offZ !== 0) {
         if (bMaxZ + offZ > 0) {
             violations.push({ axis: "z", direction: "max", overage: bMaxZ + offZ });
+        }
+    }
+
+    // Zeroed or not, the file's own Z range is a hard constraint: if it spans
+    // more than the machine's total Z travel, it goes out of bounds no matter
+    // where Z is zeroed. Travel is ceiling (machine 0, per above — zmax is not
+    // meaningful for Z) down to envelope.zmin.
+    var bMinZ = bounds.min.z;
+    if (
+        typeof bMaxZ === "number" && typeof bMinZ === "number" &&
+        typeof envelope.zmin === "number"
+    ) {
+        var zTravel = -envelope.zmin;
+        if (zTravel > 0 && bMaxZ - bMinZ > zTravel) {
+            violations.push({ axis: "z", direction: "span", overage: bMaxZ - bMinZ - zTravel });
         }
     }
 


### PR DESCRIPTION
A g55z of exactly 0 means Z has never been zeroed (a real zero always lands at a fractional offset), so the absolute Z ceiling check flagged every file on unzeroed machines. Skip it in that case.

What we still know without a zero: if the file's own Z range exceeds the machine's total Z travel (envelope zmax - zmin), it goes out of bounds no matter where Z is zeroed — warn on that unconditionally, as a new 'span' violation.

Applied to all three implementations: runtime/bounds.js (server), job_manager evaluateSoftLimits (play-button badge), and the previewer's checkSoftLimits (warning overlay), with span-specific wording in both renderers.


Claude-Session: https://claude.ai/code/session_014rxaGD2cnnZhR5H1ZourNZ