### PR TITLE
Fix manual keypad not returning after Go To move completes

### DIFF
--- a/dashboard/static/js/main.js
+++ b/dashboard/static/js/main.js
@@ -661,6 +661,9 @@ engine.getVersion(function (err, version) {
                         adjustModalHeight();
                         console.log("Status: " + status.state + "  Cmd: " + status.currentCmd);
                         if (status.stat === 5 && (status.currentCmd === "goto" || status.currentCmd === "resume")) {
+                            // Once the move is underway, drop the go-to entry state so
+                            // completion falls through to the default keypad view below
+                            in_goto_flag = false;
                             $(".manual-stop").show();
                             $(".go-to, .set-coordinates").hide();
                             keyboard.setEnabled(false);


### PR DESCRIPTION
in_goto_flag (set when an axis input gets focus) was only ever cleared by a click inside the manual-drive modal, so after a Go To move finished the status handler kept the go-to controls up and the jog keypad hidden until the user clicked again. Clear the flag once the move is underway (stat 5 / goto|resume branch) so the first status frame after completion falls through to the default keypad view.